### PR TITLE
chore: configure renovate automerge and zio grouping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,15 @@
       "matchUpdateTypes": ["minor"],
       "matchCurrentVersion": ">=1.0.0",
       "automerge": true
+    },
+    {
+      "matchPackageNames": [
+        "dev.zio:zio",
+        "dev.zio:zio-test",
+        "dev.zio:zio-test-sbt",
+        "dev.zio:zio-test-magnolia"
+      ],
+      "groupName": "zio"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Enable automerge for patch updates (all packages) and minor updates (v1+ only)
- Major updates remain manual
- Add explicit grouping for ZIO core packages (`zio`, `zio-test`, `zio-test-sbt`, `zio-test-magnolia`)
