### PR TITLE
chore: migrate from .tool-versions to devbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.bsp/
 target/
+.devbox/

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-java temurin-17.0.18+8
-sbt 1.9.9

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.16.0/.schema/devbox.schema.json",
+  "packages": [
+    "sbt@1",
+    "temurin-bin-25@latest"
+  ]
+}

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,0 +1,101 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "sbt@1": {
+      "last_modified": "2026-02-11T03:47:03Z",
+      "resolved": "github:NixOS/nixpkgs/c05d2232d2feaa4c7a07f1168606917402868195#sbt",
+      "source": "devbox-search",
+      "version": "1.12.2",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/nx8g1lv8w2qgk8wxfd73fddb8fwkz155-sbt-1.12.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/nx8g1lv8w2qgk8wxfd73fddb8fwkz155-sbt-1.12.2"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/kzki53pv6bf14y2bizbdfwqal253spph-sbt-1.12.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/kzki53pv6bf14y2bizbdfwqal253spph-sbt-1.12.2"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/6p5k1q6g5s7y7iq5limm2nz6j9jn37md-sbt-1.12.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/6p5k1q6g5s7y7iq5limm2nz6j9jn37md-sbt-1.12.2"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/9kzqlb0zbal7cwnpwm9yljq1yvdh5qr7-sbt-1.12.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/9kzqlb0zbal7cwnpwm9yljq1yvdh5qr7-sbt-1.12.2"
+        }
+      }
+    },
+    "temurin-bin-25@latest": {
+      "last_modified": "2025-10-22T20:59:19Z",
+      "resolved": "github:NixOS/nixpkgs/01b6809f7f9d1183a2b3e081f0a1e6f8f415cb09#temurin-bin-25",
+      "source": "devbox-search",
+      "version": "25.0.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/1jp5jv9ncr2n5jfxm8c2s4hdvji541yp-temurin-bin-25.0.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/1jp5jv9ncr2n5jfxm8c2s4hdvji541yp-temurin-bin-25.0.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/yjr4pmdb7nifps2fd5g9dc0kyszx6l84-temurin-bin-25.0.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/yjr4pmdb7nifps2fd5g9dc0kyszx6l84-temurin-bin-25.0.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/yg41qpbl2sj41l9anlsy8bx9sqwp2ad9-temurin-bin-25.0.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/yg41qpbl2sj41l9anlsy8bx9sqwp2ad9-temurin-bin-25.0.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/2vk2rsq58mzf3xij5n7cpq96nwg9p9sq-temurin-bin-25.0.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/2vk2rsq58mzf3xij5n7cpq96nwg9p9sq-temurin-bin-25.0.0"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Replace `.tool-versions` (asdf) with devbox for development environment management
- Packages: `temurin-bin-25@latest`, `sbt@1`
- Add `.devbox/` to `.gitignore`