### PR TITLE
fix: use blacklist approach for renovate minor automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,8 +10,12 @@
     },
     {
       "matchUpdateTypes": ["minor"],
-      "matchCurrentVersion": ">=1.0.0",
       "automerge": true
+    },
+    {
+      "matchCurrentVersion": "< 1.0.0",
+      "matchUpdateTypes": ["minor"],
+      "automerge": false
     },
     {
       "matchPackageNames": [


### PR DESCRIPTION
## Summary
- Fix minor automerge not triggering for sbt dependencies
- Replace whitelist approach (`matchCurrentVersion: ">=1.0.0"`) with blacklist approach (automerge all minor, then disable for `< 1.0.0`)
- The range condition `>=1.0.0` was not matching sbt packages, causing automerge to be silently skipped