### PR TITLE
ci: Revert Scala 3.8 upgrade and restrict Renovate to 3.3 LTS

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "3.8.2"
+ThisBuild / scalaVersion := "3.3.7"
 ThisBuild / scalacOptions ++= Seq(
   "-encoding",
   "utf8",

--- a/renovate.json
+++ b/renovate.json
@@ -30,6 +30,11 @@
       "matchManagers": ["devbox"],
       "matchPackageNames": ["sbt"],
       "enabled": false
+    },
+    {
+      "matchPackageNames": ["scala"],
+      "allowedVersions": "/^3\\.3\\./",
+      "description": "Keep default Scala version on 3.3 LTS"
     }
   ]
 }


### PR DESCRIPTION
Reverts the automerged Scala 3.8.2 upgrade and adds a Renovate `allowedVersions` rule to keep the default Scala version on the 3.3 LTS line.