### PR TITLE
ci: Fix Renovate matchPackageNames for Scala version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,7 +32,7 @@
       "enabled": false
     },
     {
-      "matchPackageNames": ["scala"],
+      "matchPackageNames": ["org.scala-lang:scala3-library_3"],
       "allowedVersions": "/^3\\.3\\./",
       "description": "Keep default Scala version on 3.3 LTS"
     }


### PR DESCRIPTION
The previous `matchPackageNames: ["scala"]` did not match the actual package name used by Renovate's sbt manager, allowing unwanted Scala 3.8.x upgrade PRs to be created.