### PR TITLE
docs: promote validateAs as the primary cursor API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,128 +1,21 @@
 # yoshi
 
-A validation library that transforms untyped input into domain types — not just checking values, but parsing them into a stronger representation.
-
-## The idea
-
-Most validation libraries give you `Validated[E, A]` — a value that's either valid or not.
-Yoshi gives you `Validation[R, V, A, B]` — a **composable function** from `A` to `B` that accumulates violations on failure.
-
-```scala
-// Untyped input — what you receive
-case class FormInput(
-  name: Option[String],
-  age: String,
-  items: List[FormInput.Item],
-)
-object FormInput:
-  case class Item(label: Option[String])
-
-// Domain type — what you want
-case class Order(
-  name: String,
-  age: Int,
-  items: List[Order.Item],
-)
-object Order:
-  case class Item(label: String)
-```
+A validation library for Scala 3 that transforms untyped input into domain types — not just checking values, but parsing them into a stronger representation.
 
 ```scala
 import yoshi.*
 import yoshi.defaults.*
 
-given Validation[Any, Violation, FormInput.Item, Order.Item] =
-  Validation.cursor[FormInput.Item] { c =>
-    (
-      c.field(_.label).validateAs[String]
-    ).validateN { label =>
-      Order.Item(label)
-    }
-  }
-
 val validation: Validation[Any, Violation, FormInput, Order] =
   Validation.cursor[FormInput] { c =>
     (
-      c.field(_.name).validateAs[String],
-      c.field(_.age).validateAs[Int],
-      c.field(_.items).validateAs[List[Order.Item]],
+      c.validateAs[String](_.name),
+      c.validateAs[Int](_.age),
+      c.validateAs[List[Order.Item]](_.items),
     ).validateN { case (name, age, items) =>
       Order(name, age, items)
     }
   }
 ```
 
-The cursor derives field names from accessor lambdas at compile time — no manual `.at("field")` strings needed.
-
-For cases where the path should differ from the field name, use `.at()` to override:
-
-```scala
-c.field(_.name).at("display_name").validateAs[String]
-```
-
-A shorthand is also available:
-
-```scala
-// These are equivalent:
-c.field(_.name).validateAs[String]
-c.validateAs[String](_.name)
-```
-
-<details>
-<summary>Without cursor (manual <code>.at()</code> calls)</summary>
-
-```scala
-val validation: Validation[Any, Violation, FormInput, Order] =
-  Validation.instance[FormInput] { dirty =>
-    (
-      dirty.name.validateAs[String].at("name"),
-      dirty.age.validateAs[Int].at("age"),
-      dirty.items.validateAs[List[Order.Item]].at("items"),
-    ).validateN { case (name, age, items) =>
-      Order(name, age, items)
-    }
-  }
-```
-
-</details>
-
-## Path-aware error accumulation
-
-Violations carry the full path to where they occurred:
-
-```scala
-validation.run(invalid).either.map {
-  case Left(violations) =>
-    violations.toList.foreach { case (path, v) => println(s"$path: $v") }
-    // name: Required
-    // age: NonIntegerString(abc)
-    // items[1].label: Required
-}
-```
-
-## Automatic container derivation
-
-Define a validator for `A → B`, and validators for `Option[A]`, `List[A]`, `Map[String, A]` are derived automatically:
-
-```scala
-// Given this exists:
-given Validation[Any, Violation, String, String] = ...
-
-// These are derived for free:
-// Validation[Any, Violation, Option[String], Option[String]]
-// Validation[Any, Violation, List[String], List[String]]
-// Validation[Any, Violation, Map[String, String], Map[String, String]]
-```
-
-## Composing validators
-
-```scala
-val nonEmpty = Validation.ensure("required")((_: String).nonEmpty)
-val maxLen   = Validation.maxLength(100)(_ => "too long")
-
-// Parallel — accumulates all violations
-val both = nonEmpty |+| maxLen
-
-// Sequential — short-circuits on first failure
-val chain = nonEmpty >> maxLen
-```
+Full documentation is available at [hshn.github.io/yoshi](https://hshn.github.io/yoshi/).

--- a/core/src/main/scala/yoshi/Cursor.scala
+++ b/core/src/main/scala/yoshi/Cursor.scala
@@ -14,10 +14,9 @@ import zio.ZIO
   * {{{
   * Validation.cursor[FormInput] { c =>
   *   (
-  *     c.field(_.name).validateAs[String],              // path "name" derived from accessor
-  *     c.field(_.age).validateAs[Int],                  // path "age" derived from accessor
-  *     c.field(_.address.zip).validateAs[String],       // path "address.zip" (nested)
-  *     c.validateAs[String](_.name),                    // shorthand for field + validateAs
+  *     c.validateAs[String](_.name),                    // path "name" derived from accessor
+  *     c.validateAs[Int](_.age),                        // path "age" derived from accessor
+  *     c.validateAs[String](_.address.zip),             // path "address.zip" (nested)
   *     c.field(_.name).at("alias").validateAs[String],  // path overridden to "alias"
   *   ).validateN { ... }
   * }
@@ -44,17 +43,19 @@ final class ValidationCursor[A](private val underlying: A):
   inline def field[B](inline f: A => B): CursorField[B] =
     new CursorField(f(underlying), Paths(fieldNames(f).map(Path.Key(_))))
 
-  /** Shorthand for `field(f).validateAs[B]` — extracts the field, validates it, and attaches the path in one step.
+  /** Validate a field in one step — extracts the field, validates it, and attaches the path.
     *
     * {{{
-    * // These are equivalent:
     * c.validateAs[String](_.name)
-    * c.field(_.name).validateAs[String]
+    * c.validateAs[Int](_.age)
+    * c.validateAs[String](_.address.zip)  // nested paths supported
     * }}}
+    *
+    * Equivalent to `c.field(_.name).validateAs[String]`. Use [[field]] when you need to override the path with `.at()`.
     */
   inline def validateAs[B] = new CursorValidateAs[A, B](underlying)
 
-/** Intermediate class for the `cursor.validateAs[B](_.field)` shorthand.
+/** Intermediate class for `cursor.validateAs[B](_.field)`.
   *
   * Not intended for direct use; obtained via [[ValidationCursor.validateAs]].
   */

--- a/core/src/main/scala/yoshi/Validation.scala
+++ b/core/src/main/scala/yoshi/Validation.scala
@@ -159,10 +159,9 @@ object Validation extends ValidationInstances {
     * val v: Validation[Any, Violation, FormInput, Order] =
     *   Validation.cursor[FormInput] { c =>
     *     (
-    *       c.field(_.name).validateAs[String],   // path "name" derived automatically
-    *       c.field(_.age).validateAs[Int],        // path "age" derived automatically
-    *       c.validateAs[String](_.name),          // shorthand for field(_.name).validateAs
-    *     ).validateN { case (name, age, _) => Order(name, age) }
+    *       c.validateAs[String](_.name),   // path "name" derived automatically
+    *       c.validateAs[Int](_.age),        // path "age" derived automatically
+    *     ).validateN { case (name, age) => Order(name, age) }
     *   }
     * }}}
     *

--- a/docs/mdoc/index.md
+++ b/docs/mdoc/index.md
@@ -55,7 +55,7 @@ object Order:
 given Validation[Any, Violation, FormInput.Item, Order.Item] =
   Validation.cursor[FormInput.Item] { c =>
     (
-      c.field(_.label).validateAs[String]
+      c.validateAs[String](_.label)
     ).validateN { label =>
       Order.Item(label)
     }
@@ -64,9 +64,9 @@ given Validation[Any, Violation, FormInput.Item, Order.Item] =
 val validation: Validation[Any, Violation, FormInput, Order] =
   Validation.cursor[FormInput] { c =>
     (
-      c.field(_.name).validateAs[String],
-      c.field(_.age).validateAs[Int],
-      c.field(_.items).validateAs[List[Order.Item]],
+      c.validateAs[String](_.name),
+      c.validateAs[Int](_.age),
+      c.validateAs[List[Order.Item]](_.items),
     ).validateN { case (name, age, items) =>
       Order(name, age, items)
     }
@@ -75,29 +75,19 @@ val validation: Validation[Any, Violation, FormInput, Order] =
 
 The cursor derives field names from accessor lambdas at compile time — no manual `.at("field")` strings needed.
 
-For cases where the path should differ from the field name, use `.at()` to override:
+When the path should differ from the field name, use `field()` with `.at()` to override:
 
 ```scala mdoc:silent
 val renamed: Validation[Any, Violation, FormInput, Order] =
   Validation.cursor[FormInput] { c =>
     (
       c.field(_.name).at("display_name").validateAs[String],
-      c.field(_.age).validateAs[Int],
-      c.field(_.items).validateAs[List[Order.Item]],
+      c.validateAs[Int](_.age),
+      c.validateAs[List[Order.Item]](_.items),
     ).validateN { case (name, age, items) =>
       Order(name, age, items)
     }
   }
-```
-
-A shorthand is also available:
-
-```scala mdoc:compile-only
-// These are equivalent:
-Validation.cursor[FormInput] { c =>
-  c.field(_.name).validateAs[String]
-  c.validateAs[String](_.name)
-}
 ```
 
 ## Path-aware error accumulation


### PR DESCRIPTION
## Summary

Establishes `c.validateAs[B](_.field)` as the idiomatic cursor style, demoting `c.field(_.name).validateAs[B]` to an escape hatch for path overrides only. Also strips the README down to a one-liner with a link to the full hosted documentation.

## Changes

- Promote `validateAs` as the primary call style in `Cursor.scala`, `Validation.scala`, and the docs
- Simplify README to a brief intro linking to the hosted docs site