### PR TITLE
refactor: migrate validation API from ZIO to Either

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 target/
 .devbox/
 .worktrees/
-website/node_modules/
+node_modules/
 website/build/
 website/docs/
 website/.docusaurus/

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+pnpm commitlint --edit $1

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A validation library for Scala 3 that transforms untyped input into domain types
 import yoshi.*
 import yoshi.defaults.*
 
-val validation: Validation[Any, Violation, FormInput, Order] =
+val validation: Validation[Violation, FormInput, Order] =
   Validation.cursor[FormInput] { c =>
     (
       c.validateAs[String](_.name),

--- a/build.sbt
+++ b/build.sbt
@@ -21,13 +21,11 @@ lazy val root = (project in file(".") withId "yoshi")
   )
   .aggregate(
     core,
-    `zio-prelude`,
   )
 
 lazy val core = (project in file("core"))
   .settings(
     libraryDependencies ++= Seq(
-      "dev.zio" %% "zio"               % zio,
       "dev.zio" %% "zio-test"          % zio % Test,
       "dev.zio" %% "zio-test-sbt"      % zio % Test,
       "dev.zio" %% "zio-test-magnolia" % zio % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ lazy val root = (project in file(".") withId "yoshi")
   )
   .aggregate(
     core,
+    `zio-prelude`,
   )
 
 lazy val core = (project in file("core"))

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+export default { extends: ['@commitlint/config-conventional'] };

--- a/core/src/main/scala/yoshi/Cursor.scala
+++ b/core/src/main/scala/yoshi/Cursor.scala
@@ -4,7 +4,6 @@ import yoshi.Violations.Path
 import yoshi.Violations.Paths
 import yoshi.internal.fieldNames
 import yoshi.syntax.ValidatedAs
-import zio.ZIO
 
 /** A cursor over a value of type `A` that provides field access with automatic path tracking.
   *
@@ -22,8 +21,6 @@ import zio.ZIO
   * }
   * }}}
   *
-  * @tparam A
-  *   the input type to extract fields from
   * @see
   *   [[Validation.cursor]] for the factory method
   * @see
@@ -60,9 +57,9 @@ final class ValidationCursor[A](private val underlying: A):
   * Not intended for direct use; obtained via [[ValidationCursor.validateAs]].
   */
 final class CursorValidateAs[A, B](private val underlying: A):
-  inline def apply[F](inline f: A => F)(using va: ValidatedAs[F, B]): ZIO[va.Env, Violations[va.Err], B] =
+  inline def apply[F](inline f: A => F)(using va: ValidatedAs[F, B]): Either[Violations[va.Err], B] =
     val paths = Paths(fieldNames(f).map(Path.Key(_)))
-    va.run(f(underlying)).mapError(_.asChild(paths))
+    va.run(f(underlying)).left.map(_.asChild(paths))
 
 /** A field value paired with its auto-derived path, obtained via [[ValidationCursor.field]].
   *
@@ -80,8 +77,8 @@ final class CursorValidateAs[A, B](private val underlying: A):
 final class CursorField[B](val value: B, val path: Paths):
 
   /** Validate this field, automatically attaching the derived (or overridden) path to any violations. */
-  def validateAs[C](using va: ValidatedAs[B, C]): ZIO[va.Env, Violations[va.Err], C] =
-    va.run(value).mapError(_.asChild(path))
+  def validateAs[C](using va: ValidatedAs[B, C]): Either[Violations[va.Err], C] =
+    va.run(value).left.map(_.asChild(path))
 
   /** Override the auto-derived path.
     *

--- a/core/src/main/scala/yoshi/Validation.scala
+++ b/core/src/main/scala/yoshi/Validation.scala
@@ -110,7 +110,7 @@ sealed abstract class Validation[+V, -A, +B] { self =>
   def orElse[V1 >: V, A1 <: A, B1 >: B](that: Validation[V1, A1, B1]): Validation[V1, A1, B1] =
     Validation.instance[A1] { a =>
       self.run(a) match {
-        case Right(b) => Right(b)
+        case Right(b)         => Right(b)
         case Left(firstError) =>
           that.run(a).left.map(_ => firstError)
       }

--- a/core/src/main/scala/yoshi/Validation.scala
+++ b/core/src/main/scala/yoshi/Validation.scala
@@ -4,8 +4,7 @@ import scala.util.matching.Regex
 
 /** A composable validation that transforms a value of type `A` into `B`, accumulating violations of type `V` on failure.
   *
-  * Validations can be composed sequentially with `>>` (short-circuit on first failure) or in parallel with `|+|` (accumulate all
-  * violations).
+  * Validations can be composed sequentially with `>>` (short-circuit on first failure) or with `|+|` (accumulate all violations).
   *
   * {{{
   * val nonEmpty: Validation[String, String, String] =
@@ -14,7 +13,7 @@ import scala.util.matching.Regex
   * val maxLen: Validation[String, String, String] =
   *   Validation.ensure("too long")(_.length <= 100)
   *
-  * // Parallel: collects violations from both
+  * // Accumulating: collects violations from both
   * val combined = nonEmpty |+| maxLen
   *
   * // Sequential: short-circuits on first failure
@@ -66,7 +65,7 @@ sealed abstract class Validation[+V, -A, +B] { self =>
       }
     }
 
-  /** Parallel composition: run both validations on the same input and accumulate all violations.
+  /** Accumulating composition: run both validations on the same input and accumulate all violations.
     *
     * If both validations succeed, the result of `this` is returned.
     *

--- a/core/src/main/scala/yoshi/Validation.scala
+++ b/core/src/main/scala/yoshi/Validation.scala
@@ -1,7 +1,6 @@
 package yoshi
 
 import scala.util.matching.Regex
-import zio.ZIO
 
 /** A composable validation that transforms a value of type `A` into `B`, accumulating violations of type `V` on failure.
   *
@@ -9,10 +8,10 @@ import zio.ZIO
   * violations).
   *
   * {{{
-  * val nonEmpty: Validation[Any, String, String, String] =
+  * val nonEmpty: Validation[String, String, String] =
   *   Validation.ensure("must not be empty")(_.nonEmpty)
   *
-  * val maxLen: Validation[Any, String, String, String] =
+  * val maxLen: Validation[String, String, String] =
   *   Validation.ensure("too long")(_.length <= 100)
   *
   * // Parallel: collects violations from both
@@ -22,8 +21,6 @@ import zio.ZIO
   * val chained = nonEmpty >> maxLen
   * }}}
   *
-  * @tparam R
-  *   ZIO environment required to run this validation
   * @tparam V
   *   violation type produced on failure
   * @tparam A
@@ -31,36 +28,36 @@ import zio.ZIO
   * @tparam B
   *   output type on success (covariant)
   */
-sealed abstract class Validation[-R, +V, -A, +B] { self =>
+sealed abstract class Validation[+V, -A, +B] { self =>
 
   /** Run this validation on the given input.
     *
     * @return
-    *   a ZIO effect that succeeds with `B` or fails with [[Violations]]
+    *   a `Right` with `B` on success, or a `Left` with [[Violations]] on failure
     */
-  def run(a: A): ZIO[R, Violations[V], B]
+  def run(a: A): Either[Violations[V], B]
 
   /** Transform the violation type produced on failure. */
-  def mapError[V1](f: V => V1): Validation[R, V1, A, B] =
+  def mapError[V1](f: V => V1): Validation[V1, A, B] =
     Validation.instance[A] { a =>
-      self.run(a).mapError(_.map(f))
+      self.run(a).left.map(_.map(f))
     }
 
   /** Adapt the input type by applying `f` before validation.
     *
     * {{{
     * case class User(name: String)
-    * val nonEmpty: Validation[Any, String, String, String] = ???
-    * val validateName: Validation[Any, String, User, String] = nonEmpty.contramap(_.name)
+    * val nonEmpty: Validation[String, String, String] = ???
+    * val validateName: Validation[String, User, String] = nonEmpty.contramap(_.name)
     * }}}
     */
-  def contramap[A0](f: A0 => A): Validation[R, V, A0, B] =
+  def contramap[A0](f: A0 => A): Validation[V, A0, B] =
     Validation.instance[A0] { a0 =>
       self.run(f(a0))
     }
 
   /** Transform the output value after a successful validation. */
-  def map[C](f: B => C): Validation[R, V, A, C] =
+  def map[C](f: B => C): Validation[V, A, C] =
     Validation.instance[A] { a =>
       for {
         b <- run(a)
@@ -78,10 +75,10 @@ sealed abstract class Validation[-R, +V, -A, +B] { self =>
     * // If input is "" with length 0, both violations are collected
     * }}}
     */
-  def |+|[R1 <: R, V1 >: V, A1 <: A, B1 >: B](next: Validation[R1, V1, A1, B1]): Validation[R1, V1, A1, B1] =
+  def |+|[V1 >: V, A1 <: A, B1 >: B](next: Validation[V1, A1, B1]): Validation[V1, A1, B1] =
     Validation.instance { a =>
-      val lhs: ZIO[R1, Violations[V1], B1] = run(a)
-      val rhs: ZIO[R1, Violations[V1], B1] = next.run(a)
+      val lhs: Either[Violations[V1], B1] = run(a)
+      val rhs: Either[Violations[V1], B1] = next.run(a)
       (lhs, rhs).validateN { case (b1, _) => b1 }
     }
 
@@ -90,12 +87,12 @@ sealed abstract class Validation[-R, +V, -A, +B] { self =>
     * Short-circuits on the first failure without running `next`.
     *
     * {{{
-    * val parseInt: Validation[Any, String, String, Int] = ???
-    * val positive: Validation[Any, String, Int, Int] = ???
+    * val parseInt: Validation[String, String, Int] = ???
+    * val positive: Validation[String, Int, Int] = ???
     * val positiveInt = parseInt >> positive
     * }}}
     */
-  def >>[C, R1 <: R, V1 >: V](next: Validation[R1, V1, B, C]): Validation[R1, V1, A, C] =
+  def >>[C, V1 >: V](next: Validation[V1, B, C]): Validation[V1, A, C] =
     Validation.instance[A] { a =>
       for {
         b <- run(a)
@@ -110,44 +107,46 @@ sealed abstract class Validation[-R, +V, -A, +B] { self =>
     * If `this` succeeds, its result is returned. If `this` fails, `that` is attempted; if `that` also fails, the violations from `this`
     * (the first attempt) are returned.
     */
-  def orElse[R1 <: R, V1 >: V, A1 <: A, B1 >: B](that: Validation[R1, V1, A1, B1]): Validation[R1, V1, A1, B1] =
+  def orElse[V1 >: V, A1 <: A, B1 >: B](that: Validation[V1, A1, B1]): Validation[V1, A1, B1] =
     Validation.instance[A1] { a =>
-      self.run(a).catchAll { firstError =>
-        that.run(a).mapError(_ => firstError)
+      self.run(a) match {
+        case Right(b) => Right(b)
+        case Left(firstError) =>
+          that.run(a).left.map(_ => firstError)
       }
     }
 
   /** Lift this validation to handle `Option`: `None` passes through as `None`, `Some(a)` is validated and wrapped back in `Some` on
     * success.
     */
-  def optional: Validation[R, V, Option[A], Option[B]] =
+  def optional: Validation[V, Option[A], Option[B]] =
     Validation.instance[Option[A]] {
       case Some(a) => self.run(a).map(Some(_))
-      case None    => ZIO.succeed(None)
+      case None    => Right(None)
     }
 }
 
 /** Factory methods and given instances for [[Validation]]. */
 object Validation extends ValidationInstances {
 
-  final private class Impl[-R, +V, -A, +B](f: A => ZIO[R, Violations[V], B]) extends Validation[R, V, A, B] {
-    def run(a: A): ZIO[R, Violations[V], B] = f(a)
+  final private class Impl[+V, -A, +B](f: A => Either[Violations[V], B]) extends Validation[V, A, B] {
+    def run(a: A): Either[Violations[V], B] = f(a)
   }
 
-  /** Create a [[Validation]] from a function that returns a ZIO effect.
+  /** Create a [[Validation]] from a function that returns an `Either`.
     *
     * {{{
-    * val positive: Validation[Any, String, Int, Int] =
+    * val positive: Validation[String, Int, Int] =
     *   Validation.instance[Int] { n =>
-    *     if (n > 0) ZIO.succeed(n)
-    *     else ZIO.fail(Violations.of("must be positive"))
+    *     if (n > 0) Right(n)
+    *     else Left(Violations.of("must be positive"))
     *   }
     * }}}
     */
   def instance[A] = new InstancePartiallyApplied[A]
 
   final class InstancePartiallyApplied[A] {
-    def apply[R, V, B](f: A => ZIO[R, Violations[V], B]): Validation[R, V, A, B] = new Impl(f)
+    def apply[V, B](f: A => Either[Violations[V], B]): Validation[V, A, B] = new Impl(f)
   }
 
   /** Create a [[Validation]] from a function that receives a [[ValidationCursor]].
@@ -156,7 +155,7 @@ object Validation extends ValidationInstances {
     * extracted from the accessor lambda at compile time.
     *
     * {{{
-    * val v: Validation[Any, Violation, FormInput, Order] =
+    * val v: Validation[Violation, FormInput, Order] =
     *   Validation.cursor[FormInput] { c =>
     *     (
     *       c.validateAs[String](_.name),   // path "name" derived automatically
@@ -173,17 +172,17 @@ object Validation extends ValidationInstances {
   def cursor[A] = new CursorPartiallyApplied[A]
 
   final class CursorPartiallyApplied[A] {
-    def apply[R, V, B](f: ValidationCursor[A] => ZIO[R, Violations[V], B]): Validation[R, V, A, B] =
+    def apply[V, B](f: ValidationCursor[A] => Either[Violations[V], B]): Validation[V, A, B] =
       new Impl(a => f(new ValidationCursor(a)))
   }
 
   /** A validation that always succeeds, passing the input through unchanged. */
-  def succeed[A]: Validation[Any, Nothing, A, A] =
-    instance[A](a => ZIO.succeed(a))
+  def succeed[A]: Validation[Nothing, A, A] =
+    instance[A](a => Right(a))
 
   /** A validation that always fails with the given violation. */
-  def fail[V](v: V): Validation[Any, V, Any, Nothing] =
-    instance[Any](_ => ZIO.fail(Violations.of(v)))
+  def fail[V](v: V): Validation[V, Any, Nothing] =
+    instance[Any](_ => Left(Violations.of(v)))
 
   /** Validate that a predicate holds, failing with a constant violation if it does not.
     *
@@ -191,15 +190,15 @@ object Validation extends ValidationInstances {
     * val nonEmpty = Validation.ensure("must not be empty")((_: String).nonEmpty)
     * }}}
     */
-  def ensure[V, A](f: => V)(test: A => Boolean): Validation[Any, V, A, A] =
+  def ensure[V, A](f: => V)(test: A => Boolean): Validation[V, A, A] =
     ensureOr[V, A](_ => f)(test)
 
   /** Validate that a predicate holds, computing the violation from the input value. */
-  def ensureOr[V, A](f: A => V)(test: A => Boolean): Validation[Any, V, A, A] = instance[A] { a =>
+  def ensureOr[V, A](f: A => V)(test: A => Boolean): Validation[V, A, A] = instance[A] { a =>
     if (test(a))
-      ZIO.succeed(a)
+      Right(a)
     else
-      ZIO.fail(Violations.of(f(a)))
+      Left(Violations.of(f(a)))
   }
 
   /** Extract a value from `Option`, failing with the given violation if `None`.
@@ -210,24 +209,21 @@ object Validation extends ValidationInstances {
     * req.run(None)     // fails with "field is required"
     * }}}
     */
-  def required[V, A](error: => V): Validation[Any, V, Option[A], A] =
+  def required[V, A](error: => V): Validation[V, Option[A], A] =
     instance[Option[A]] { maybeA =>
-      ZIO.fromEither(maybeA.toRight(Violations.of(error)))
+      maybeA.toRight(Violations.of(error))
     }
 
   /** Parse a `String` to `Int`, failing with a violation produced from the original string on `NumberFormatException`.
     */
-  def parseInt[V](error: String => V): Validation[Any, V, String, Int] =
+  def parseInt[V](error: String => V): Validation[V, String, Int] =
     instance[String] { value =>
-      ZIO
-        .attempt(Integer.parseInt(value))
-        .refineOrDie { case _: NumberFormatException =>
-          Violations.of(error(value))
-        }
+      try Right(Integer.parseInt(value))
+      catch { case _: NumberFormatException => Left(Violations.of(error(value))) }
     }
 
   /** Validate that a string's length does not exceed `max`. */
-  def maxLength[V](max: Int)(error: (String, Int) => V): Validation[Any, V, String, String] =
+  def maxLength[V](max: Int)(error: (String, Int) => V): Validation[V, String, String] =
     ensureOr[V, String] { value =>
       error(value, max)
     } { value =>
@@ -235,7 +231,7 @@ object Validation extends ValidationInstances {
     }
 
   /** Validate that a string's length is at least `min`. */
-  def minLength[V](min: Int)(error: (String, Int) => V): Validation[Any, V, String, String] =
+  def minLength[V](min: Int)(error: (String, Int) => V): Validation[V, String, String] =
     ensureOr[V, String] { value =>
       error(value, min)
     } { value =>
@@ -243,22 +239,22 @@ object Validation extends ValidationInstances {
     }
 
   /** Validate that an integer is greater than or equal to `n`. */
-  def min[V](n: Int)(error: Int => V): Validation[Any, V, Int, Int] =
+  def min[V](n: Int)(error: Int => V): Validation[V, Int, Int] =
     ensureOr[V, Int](error)(_ >= n)
 
   /** Validate that an integer is less than or equal to `n`. */
-  def max[V](n: Int)(error: Int => V): Validation[Any, V, Int, Int] =
+  def max[V](n: Int)(error: Int => V): Validation[V, Int, Int] =
     ensureOr[V, Int](error)(_ <= n)
 
   /** Validate that an integer is strictly positive (greater than zero). */
-  def positive[V](error: Int => V): Validation[Any, V, Int, Int] =
+  def positive[V](error: Int => V): Validation[V, Int, Int] =
     ensureOr[V, Int](error)(_ > 0)
 
   /** Validate that a string matches the given regex pattern. */
-  def matches[V](pattern: Regex)(error: (String, Regex) => V): Validation[Any, V, String, String] =
+  def matches[V](pattern: Regex)(error: (String, Regex) => V): Validation[V, String, String] =
     instance[String] { value =>
-      if (pattern.matches(value)) ZIO.succeed(value)
-      else ZIO.fail(Violations.of(error(value, pattern)))
+      if (pattern.matches(value)) Right(value)
+      else Left(Violations.of(error(value, pattern)))
     }
 
 }

--- a/core/src/main/scala/yoshi/ValidationInstances.scala
+++ b/core/src/main/scala/yoshi/ValidationInstances.scala
@@ -2,8 +2,7 @@ package yoshi
 
 trait ValidationInstances {
 
-  /** Automatically lifts a `Validation[V, A, B]` to `Validation[V, Option[A], Option[B]]`. `None` passes through; `Some(a)` is
-    * validated.
+  /** Automatically lifts a `Validation[V, A, B]` to `Validation[V, Option[A], Option[B]]`. `None` passes through; `Some(a)` is validated.
     */
   given optionCanBeValidatedAs[V, A, B](using validation: Validation[V, A, B]): Validation[V, Option[A], Option[B]] =
     validation.optional

--- a/core/src/main/scala/yoshi/ValidationInstances.scala
+++ b/core/src/main/scala/yoshi/ValidationInstances.scala
@@ -1,48 +1,38 @@
 package yoshi
 
-import zio.ZIO
-
 trait ValidationInstances {
 
-  /** Automatically lifts a `Validation[R, V, A, B]` to `Validation[R, V, Option[A], Option[B]]`. `None` passes through; `Some(a)` is
+  /** Automatically lifts a `Validation[V, A, B]` to `Validation[V, Option[A], Option[B]]`. `None` passes through; `Some(a)` is
     * validated.
     */
-  given optionCanBeValidatedAs[R, V, A, B](using validation: Validation[R, V, A, B]): Validation[R, V, Option[A], Option[B]] =
+  given optionCanBeValidatedAs[V, A, B](using validation: Validation[V, A, B]): Validation[V, Option[A], Option[B]] =
     validation.optional
 
   /** Automatically validates each element of a `Seq`, accumulating violations by index. */
-  given seqCanBeValidatedAs[R, V, A, B](using validation: Validation[R, V, A, B]): Validation[R, V, Seq[A], Seq[B]] =
+  given seqCanBeValidatedAs[V, A, B](using validation: Validation[V, A, B]): Validation[V, Seq[A], Seq[B]] =
     Validation.instance { values =>
-      ZIO
-        .foreach(values.toList.zipWithIndex) { case (a, index) =>
-          validation.run(a).at(index).either
-        }
-        .map { results =>
-          val (errors, successes) = results.partitionMap(identity)
-          if (errors.isEmpty) Right(successes)
-          else Left(errors.reduce(_ ++ _))
-        }
-        .absolve
+      val results = values.toList.zipWithIndex.map { case (a, index) =>
+        validation.run(a).left.map(_.asChild(Violations.Path.Index(index)))
+      }
+      val (errors, successes) = results.partitionMap(identity)
+      if (errors.isEmpty) Right(successes)
+      else Left(errors.reduce(_ ++ _))
     }
 
   /** Automatically validates each element of a `List`, accumulating violations by index. */
-  given listCanBeValidatedAs[R, V, A, B](using Validation[R, V, A, B]): Validation[R, V, List[A], List[B]] =
-    seqCanBeValidatedAs[R, V, A, B].contramap[List[A]](identity).map(_.toList)
+  given listCanBeValidatedAs[V, A, B](using Validation[V, A, B]): Validation[V, List[A], List[B]] =
+    seqCanBeValidatedAs[V, A, B].contramap[List[A]](identity).map(_.toList)
 
   /** Automatically validates each value of a `Map[String, A]`, accumulating violations by key. */
-  given mapCanBeValidatedAs[R, V, A, B](using
-    validation: Validation[R, V, A, B],
-  ): Validation[R, V, Map[String, A], Map[String, B]] =
+  given mapCanBeValidatedAs[V, A, B](using
+    validation: Validation[V, A, B],
+  ): Validation[V, Map[String, A], Map[String, B]] =
     Validation.instance { values =>
-      ZIO
-        .foreach(values.toList) { case (key, a) =>
-          validation.run(a).at(key).map(b => key -> b).either
-        }
-        .map { results =>
-          val (errors, successes) = results.partitionMap(identity)
-          if (errors.isEmpty) Right(successes.toMap)
-          else Left(errors.reduce(_ ++ _))
-        }
-        .absolve
+      val results = values.toList.map { case (key, a) =>
+        validation.run(a).left.map(_.asChild(Violations.Path.Key(key))).map(b => key -> b)
+      }
+      val (errors, successes) = results.partitionMap(identity)
+      if (errors.isEmpty) Right(successes.toMap)
+      else Left(errors.reduce(_ ++ _))
     }
 }

--- a/core/src/main/scala/yoshi/defaults/ValidationInstances.scala
+++ b/core/src/main/scala/yoshi/defaults/ValidationInstances.scala
@@ -2,8 +2,8 @@ package yoshi.defaults
 
 import yoshi.Validation
 
-implicit def optionCanBeDefined[A]: Validation[Any, Violation, Option[A], A] =
+implicit def optionCanBeDefined[A]: Validation[Violation, Option[A], A] =
   Validations.required
 
-implicit val stringCanBeInt: Validation[Any, Violation, String, Int] =
+implicit val stringCanBeInt: Validation[Violation, String, Int] =
   Validations.parseInt

--- a/core/src/main/scala/yoshi/defaults/Validations.scala
+++ b/core/src/main/scala/yoshi/defaults/Validations.scala
@@ -5,28 +5,28 @@ import yoshi.*
 
 object Validations {
 
-  def required[A]: Validation[Any, Violation, Option[A], A] =
+  def required[A]: Validation[Violation, Option[A], A] =
     Validation.required(Violation.Required)
 
-  def parseInt: Validation[Any, Violation, String, Int] =
+  def parseInt: Validation[Violation, String, Int] =
     Validation.parseInt(Violation.NonIntegerString(_))
 
-  def maxLength(max: Int): Validation[Any, Violation, String, String] =
+  def maxLength(max: Int): Validation[Violation, String, String] =
     Validation.maxLength(max)(Violation.TooLongString(_, _))
 
-  def minLength(min: Int): Validation[Any, Violation, String, String] =
+  def minLength(min: Int): Validation[Violation, String, String] =
     Validation.minLength(min)(Violation.TooShortString(_, _))
 
-  def matches(pattern: Regex): Validation[Any, Violation, String, String] =
+  def matches(pattern: Regex): Validation[Violation, String, String] =
     Validation.matches(pattern)(Violation.Unmatched(_, _))
 
-  def min(n: Int): Validation[Any, Violation, Int, Int] =
+  def min(n: Int): Validation[Violation, Int, Int] =
     Validation.min(n)(Violation.TooSmall(_, n))
 
-  def max(n: Int): Validation[Any, Violation, Int, Int] =
+  def max(n: Int): Validation[Violation, Int, Int] =
     Validation.max(n)(Violation.TooLarge(_, n))
 
-  def positive: Validation[Any, Violation, Int, Int] =
+  def positive: Validation[Violation, Int, Int] =
     Validation.positive(Violation.NonPositive(_))
 
 }

--- a/core/src/main/scala/yoshi/syntax/ValidateAs.scala
+++ b/core/src/main/scala/yoshi/syntax/ValidateAs.scala
@@ -2,40 +2,37 @@ package yoshi.syntax
 
 import yoshi.Validation
 import yoshi.Violations
-import zio.ZIO
 
-/** Provides `.validateAs[B]` on any value and `.at(path)` on ZIO effects that fail with [[Violations]].
+/** Provides `.validateAs[B]` on any value and `.at(path)` on `Either` values that fail with [[Violations]].
   *
   * {{{
   * import yoshi.defaults.*
   *
-  * val result: ZIO[Any, Violations[Violation], Int] = "42".validateAs[Int]
-  * val atField: ZIO[Any, Violations[Violation], Int] = "42".validateAs[Int].at("age")
+  * val result: Either[Violations[Violation], Int] = "42".validateAs[Int]
+  * val atField: Either[Violations[Violation], Int] = "42".validateAs[Int].at("age")
   * }}}
   */
 trait ValidateAs:
-  extension [A](a: A) def validateAs[B](using va: ValidatedAs[A, B]): ZIO[va.Env, Violations[va.Err], B] = va.run(a)
+  extension [A](a: A) def validateAs[B](using va: ValidatedAs[A, B]): Either[Violations[va.Err], B] = va.run(a)
 
-  extension [R, V, A](value: ZIO[R, Violations[V], A])
-    def at(path: Violations.Path): ZIO[R, Violations[V], A] = value.mapError(_.asChild(path))
-    def at(key: String): ZIO[R, Violations[V], A]           = at(Violations.Path.Key(key))
-    def at(index: Int): ZIO[R, Violations[V], A]            = at(Violations.Path.Index(index))
+  extension [V, A](value: Either[Violations[V], A])
+    def at(path: Violations.Path): Either[Violations[V], A] = value.left.map(_.asChild(path))
+    def at(key: String): Either[Violations[V], A]           = at(Violations.Path.Key(key))
+    def at(index: Int): Either[Violations[V], A]            = at(Violations.Path.Index(index))
 
-/** Bridge typeclass that captures a [[Validation]] with its environment and error types as type members.
+/** Bridge typeclass that captures a [[Validation]] with its error type as a type member.
   *
   * Instances are derived automatically via `transparent inline given` from any [[Validation]] in implicit scope, allowing the compiler to
-  * resolve the concrete `Env` and `Err` types at each use site.
+  * resolve the concrete `Err` type at each use site.
   */
 sealed trait ValidatedAs[-A, +B]:
-  type Env
   type Err
-  def run(a: A): ZIO[Env, Violations[Err], B]
+  def run(a: A): Either[Violations[Err], B]
 
 object ValidatedAs:
-  final class Derived[R, V, A, B](v: Validation[R, V, A, B]) extends ValidatedAs[A, B]:
-    type Env = R
+  final class Derived[V, A, B](v: Validation[V, A, B]) extends ValidatedAs[A, B]:
     type Err = V
-    def run(a: A): ZIO[R, Violations[V], B] = v.run(a)
+    def run(a: A): Either[Violations[V], B] = v.run(a)
 
-  transparent inline given derive[R, V, A, B](using v: Validation[R, V, A, B]): ValidatedAs[A, B] =
+  transparent inline given derive[V, A, B](using v: Validation[V, A, B]): ValidatedAs[A, B] =
     new Derived(v)

--- a/core/src/main/scala/yoshi/syntax/ValidateN.scala
+++ b/core/src/main/scala/yoshi/syntax/ValidateN.scala
@@ -2,7 +2,7 @@ package yoshi.syntax
 
 import yoshi.Violations
 
-/** Provides `.validateN(f)` for parallel validation of multiple `Either` values.
+/** Provides `.validateN(f)` for error-accumulating validation of multiple `Either` values.
   *
   * {{{
   * (

--- a/core/src/main/scala/yoshi/syntax/ValidateN.scala
+++ b/core/src/main/scala/yoshi/syntax/ValidateN.scala
@@ -1,9 +1,8 @@
 package yoshi.syntax
 
 import yoshi.Violations
-import zio.ZIO
 
-/** Provides `.validateN(f)` for parallel validation of multiple ZIO effects.
+/** Provides `.validateN(f)` for parallel validation of multiple `Either` values.
   *
   * {{{
   * (
@@ -13,33 +12,29 @@ import zio.ZIO
   * }}}
   */
 trait ValidateN:
-  extension [R, V, A](validation: ZIO[R, Violations[V], A])
-    def validateN[B](f: A => B): ZIO[R, Violations[V], B] =
+  extension [V, A](validation: Either[Violations[V], A])
+    def validateN[B](f: A => B): Either[Violations[V], B] =
       validation.map(f)
 
-  extension [R, V, T <: Tuple, Out <: Tuple](validations: T)(using tv: ValidateTuple[R, V, T, Out])
-    def validateN[A](f: Out => A): ZIO[R, Violations[V], A] =
-      tv.validate(validations)
-        .map(_.map(f))
-        .absolve
+  extension [V, T <: Tuple, Out <: Tuple](validations: T)(using tv: ValidateTuple[V, T, Out])
+    def validateN[A](f: Out => A): Either[Violations[V], A] =
+      tv.validate(validations).map(f)
 
-sealed trait ValidateTuple[R, V, T <: Tuple, Out <: Tuple]:
-  def validate(t: T): ZIO[R, Nothing, Either[Violations[V], Out]]
+sealed trait ValidateTuple[V, T <: Tuple, Out <: Tuple]:
+  def validate(t: T): Either[Violations[V], Out]
 
 object ValidateTuple:
-  given empty[R, V]: ValidateTuple[R, V, EmptyTuple, EmptyTuple] with
-    def validate(t: EmptyTuple): ZIO[R, Nothing, Either[Violations[V], EmptyTuple]] =
-      ZIO.succeed(Right(EmptyTuple))
+  given empty[V]: ValidateTuple[V, EmptyTuple, EmptyTuple] with
+    def validate(t: EmptyTuple): Either[Violations[V], EmptyTuple] =
+      Right(EmptyTuple)
 
-  given cons[R, V, H, T <: Tuple, TOut <: Tuple](using
-    tail: ValidateTuple[R, V, T, TOut],
-  ): ValidateTuple[R, V, ZIO[R, Violations[V], H] *: T, H *: TOut] with
-    def validate(t: ZIO[R, Violations[V], H] *: T): ZIO[R, Nothing, Either[Violations[V], H *: TOut]] =
-      t.head.either
-        .zipPar(tail.validate(t.tail))
-        .map {
-          case (Right(h), Right(t)) => Right(h *: t)
-          case (Left(e1), Left(e2)) => Left(e1 ++ e2)
-          case (Left(e), _)         => Left(e)
-          case (_, Left(e))         => Left(e)
-        }
+  given cons[V, H, T <: Tuple, TOut <: Tuple](using
+    tail: ValidateTuple[V, T, TOut],
+  ): ValidateTuple[V, Either[Violations[V], H] *: T, H *: TOut] with
+    def validate(t: Either[Violations[V], H] *: T): Either[Violations[V], H *: TOut] =
+      (t.head, tail.validate(t.tail)) match {
+        case (Right(h), Right(t)) => Right(h *: t)
+        case (Left(e1), Left(e2)) => Left(e1 ++ e2)
+        case (Left(e), _)         => Left(e)
+        case (_, Left(e))         => Left(e)
+      }

--- a/core/src/test/scala/yoshi/CursorSpec.scala
+++ b/core/src/test/scala/yoshi/CursorSpec.scala
@@ -60,7 +60,11 @@ object CursorSpec extends ZIOSpecDefault {
           items = List(Output.Item("item1"), Output.Item("item2")),
         )
 
-        assertTrue(validation.run(input).is(_.right) == expected)
+        for {
+          result <- validation.run(input)
+        } yield {
+          assertTrue(result == expected)
+        }
       }
 
       test("accumulates violations with correct paths") {

--- a/core/src/test/scala/yoshi/CursorSpec.scala
+++ b/core/src/test/scala/yoshi/CursorSpec.scala
@@ -60,7 +60,7 @@ object CursorSpec extends ZIOSpecDefault {
           items = List(Output.Item("item1"), Output.Item("item2")),
         )
 
-        assertTrue(validation.run(input) == Right(expected))
+        assertTrue(validation.run(input).is(_.right) == expected)
       }
 
       test("accumulates violations with correct paths") {
@@ -83,7 +83,7 @@ object CursorSpec extends ZIOSpecDefault {
           ),
         )
 
-        assertTrue(validation.run(input) == Left(expected))
+        assertTrue(validation.run(input).is(_.left) == expected)
       }
 
       test("produces same result as manual .at() calls") {
@@ -124,7 +124,7 @@ object CursorSpec extends ZIOSpecDefault {
             ),
           ),
         )
-        assertTrue(v.run(input) == Left(expected))
+        assertTrue(v.run(input).is(_.left) == expected)
       }
     }
 
@@ -140,7 +140,7 @@ object CursorSpec extends ZIOSpecDefault {
             Violations.Path("display_name") -> Violations(Vector(Violation.Required)),
           ),
         )
-        assertTrue(v.run(Input(name = None, age = "", items = Nil, address = Input.Address(None))) == Left(expected))
+        assertTrue(v.run(Input(name = None, age = "", items = Nil, address = Input.Address(None))).is(_.left) == expected)
       }
     }
 

--- a/core/src/test/scala/yoshi/CursorSpec.scala
+++ b/core/src/test/scala/yoshi/CursorSpec.scala
@@ -25,7 +25,7 @@ object CursorSpec extends ZIOSpecDefault {
   object Output:
     case class Item(label: String)
 
-  given Validation[Any, Violation, Input.Item, Output.Item] =
+  given Validation[Violation, Input.Item, Output.Item] =
     Validation.cursor[Input.Item] { c =>
       (
         c.field(_.label).validateAs[String]
@@ -34,7 +34,7 @@ object CursorSpec extends ZIOSpecDefault {
       }
     }
 
-  val validation: Validation[Any, Violation, Input, Output] =
+  val validation: Validation[Violation, Input, Output] =
     Validation.cursor[Input] { c =>
       (
         c.field(_.name).validateAs[String],
@@ -60,8 +60,7 @@ object CursorSpec extends ZIOSpecDefault {
           items = List(Output.Item("item1"), Output.Item("item2")),
         )
 
-        for result <- validation.run(input)
-        yield assertTrue(result == expected)
+        assertTrue(validation.run(input) == Right(expected))
       }
 
       test("accumulates violations with correct paths") {
@@ -84,12 +83,11 @@ object CursorSpec extends ZIOSpecDefault {
           ),
         )
 
-        for result <- validation.run(input).either
-        yield assertTrue(result == Left(expected))
+        assertTrue(validation.run(input) == Left(expected))
       }
 
       test("produces same result as manual .at() calls") {
-        val manualValidation: Validation[Any, Violation, Input, Output] =
+        val manualValidation: Validation[Violation, Input, Output] =
           Validation.instance[Input] { dirty =>
             (
               dirty.name.validateAs[String].at("name"),
@@ -102,75 +100,67 @@ object CursorSpec extends ZIOSpecDefault {
 
         val invalid = Input(name = None, age = "xyz", items = List(Input.Item(None)), address = Input.Address(None))
 
-        for
-          cursorResult <- validation.run(invalid).either
-          manualResult <- manualValidation.run(invalid).either
-        yield assertTrue(cursorResult == manualResult)
+        val cursorResult = validation.run(invalid)
+        val manualResult = manualValidation.run(invalid)
+        assertTrue(cursorResult == manualResult)
       }
     }
 
     suiteAll("nested field access") {
       test("derives full path from nested accessor") {
-        val v: Validation[Any, Violation, Input, String] =
+        val v: Validation[Violation, Input, String] =
           Validation.cursor[Input] { c =>
             c.field(_.address.zip).validateAs[String]
           }
 
         val input = Input(name = None, age = "", items = Nil, address = Input.Address(None))
 
-        for result <- v.run(input).either
-        yield {
-          val expected = Violations[Violation](
-            children = Map(
-              Violations.Path("address") -> Violations(
-                children = Map(
-                  Violations.Path("zip") -> Violations(Vector(Violation.Required)),
-                ),
+        val expected = Violations[Violation](
+          children = Map(
+            Violations.Path("address") -> Violations(
+              children = Map(
+                Violations.Path("zip") -> Violations(Vector(Violation.Required)),
               ),
             ),
-          )
-          assertTrue(result == Left(expected))
-        }
+          ),
+        )
+        assertTrue(v.run(input) == Left(expected))
       }
     }
 
     suiteAll("field with .at() override") {
       test("uses overridden path instead of derived name") {
-        val v: Validation[Any, Violation, Input, String] =
+        val v: Validation[Violation, Input, String] =
           Validation.cursor[Input] { c =>
             c.field(_.name).at("display_name").validateAs[String]
           }
 
-        for result <- v.run(Input(name = None, age = "", items = Nil, address = Input.Address(None))).either
-        yield {
-          val expected = Violations[Violation](
-            children = Map(
-              Violations.Path("display_name") -> Violations(Vector(Violation.Required)),
-            ),
-          )
-          assertTrue(result == Left(expected))
-        }
+        val expected = Violations[Violation](
+          children = Map(
+            Violations.Path("display_name") -> Violations(Vector(Violation.Required)),
+          ),
+        )
+        assertTrue(v.run(Input(name = None, age = "", items = Nil, address = Input.Address(None))) == Left(expected))
       }
     }
 
     suiteAll("validateAs shorthand") {
       test("produces same result as field().validateAs") {
-        val withField: Validation[Any, Violation, Input, String] =
+        val withField: Validation[Violation, Input, String] =
           Validation.cursor[Input] { c =>
             c.field(_.name).validateAs[String]
           }
 
-        val withShorthand: Validation[Any, Violation, Input, String] =
+        val withShorthand: Validation[Violation, Input, String] =
           Validation.cursor[Input] { c =>
             c.validateAs[String](_.name)
           }
 
         val invalid = Input(name = None, age = "", items = Nil, address = Input.Address(None))
 
-        for
-          fieldResult     <- withField.run(invalid).either
-          shorthandResult <- withShorthand.run(invalid).either
-        yield assertTrue(fieldResult == shorthandResult)
+        val fieldResult     = withField.run(invalid)
+        val shorthandResult = withShorthand.run(invalid)
+        assertTrue(fieldResult == shorthandResult)
       }
     }
   }

--- a/core/src/test/scala/yoshi/ValidationCombinatorsSpec.scala
+++ b/core/src/test/scala/yoshi/ValidationCombinatorsSpec.scala
@@ -22,7 +22,11 @@ object ValidationCombinatorsSpec extends ZIOSpecDefault {
         val validation = (Validations.minLength(1) |+| Validations.maxLength(2))
           .map(_.length)
 
-        assertTrue(validation.run("ab").is(_.right) == 2)
+        for {
+          result <- validation.run("ab")
+        } yield {
+          assertTrue(result == 2)
+        }
       }
       test("return left value when both succeed") {
         val left: Validation[Violation, String, String] =
@@ -30,7 +34,11 @@ object ValidationCombinatorsSpec extends ZIOSpecDefault {
         val right: Validation[Violation, String, String] =
           Validation.instance[String](s => Right(s.toLowerCase))
 
-        assertTrue((left |+| right).run("Ab").is(_.right) == "AB")
+        for {
+          result <- (left |+| right).run("Ab")
+        } yield {
+          assertTrue(result == "AB")
+        }
       }
     }
     suiteAll(">>") {
@@ -40,7 +48,11 @@ object ValidationCombinatorsSpec extends ZIOSpecDefault {
           Right(s.length)
         }
 
-        assertTrue((first >> second).run("hello").is(_.right) == 5)
+        for {
+          result <- (first >> second).run("hello")
+        } yield {
+          assertTrue(result == 5)
+        }
       }
       test("fail on first validation") {
         val first: Validation[Violation, String, String] = Validations.minLength(10)
@@ -69,13 +81,21 @@ object ValidationCombinatorsSpec extends ZIOSpecDefault {
         val first: Validation[Violation, String, String]  = Validations.minLength(1)
         val second: Validation[Violation, String, String] = Validations.minLength(5)
 
-        assertTrue(first.orElse(second).run("ab").is(_.right) == "ab")
+        for {
+          result <- first.orElse(second).run("ab")
+        } yield {
+          assertTrue(result == "ab")
+        }
       }
       test("fall back to second when first fails") {
         val first: Validation[Violation, String, String]  = Validations.minLength(10)
         val second: Validation[Violation, String, String] = Validations.minLength(1)
 
-        assertTrue(first.orElse(second).run("hello").is(_.right) == "hello")
+        for {
+          result <- first.orElse(second).run("hello")
+        } yield {
+          assertTrue(result == "hello")
+        }
       }
       test("return first violation when both fail") {
         val first: Validation[Violation, String, String]  = Validations.minLength(10)
@@ -88,7 +108,11 @@ object ValidationCombinatorsSpec extends ZIOSpecDefault {
         val first  = Validation.instance[String](s => Right(s))
         val second = Validation.instance[String] { _ => called = true; Right("fallback") }
         val result = first.orElse(second).run("ok")
-        assertTrue(result.is(_.right) == "ok", !called)
+        for {
+          r <- result
+        } yield {
+          assertTrue(r == "ok", !called)
+        }
       }
     }
   }

--- a/core/src/test/scala/yoshi/ValidationCombinatorsSpec.scala
+++ b/core/src/test/scala/yoshi/ValidationCombinatorsSpec.scala
@@ -16,13 +16,13 @@ object ValidationCombinatorsSpec extends ZIOSpecDefault {
           ),
         )
 
-        assertTrue(validation.run("ab") == Left(expectedViolations))
+        assertTrue(validation.run("ab").is(_.left) == expectedViolations)
       }
       test("result value when valid") {
         val validation = (Validations.minLength(1) |+| Validations.maxLength(2))
           .map(_.length)
 
-        assertTrue(validation.run("ab") == Right(2))
+        assertTrue(validation.run("ab").is(_.right) == 2)
       }
       test("return left value when both succeed") {
         val left: Validation[Violation, String, String] =
@@ -30,7 +30,7 @@ object ValidationCombinatorsSpec extends ZIOSpecDefault {
         val right: Validation[Violation, String, String] =
           Validation.instance[String](s => Right(s.toLowerCase))
 
-        assertTrue((left |+| right).run("Ab") == Right("AB"))
+        assertTrue((left |+| right).run("Ab").is(_.right) == "AB")
       }
     }
     suiteAll(">>") {
@@ -40,7 +40,7 @@ object ValidationCombinatorsSpec extends ZIOSpecDefault {
           Right(s.length)
         }
 
-        assertTrue((first >> second).run("hello") == Right(5))
+        assertTrue((first >> second).run("hello").is(_.right) == 5)
       }
       test("fail on first validation") {
         val first: Validation[Violation, String, String] = Validations.minLength(10)
@@ -48,13 +48,13 @@ object ValidationCombinatorsSpec extends ZIOSpecDefault {
           Right(s.length)
         }
 
-        assertTrue((first >> second).run("hi") == Left(Violations.of(Violation.TooShortString("hi", 10))))
+        assertTrue((first >> second).run("hi").is(_.left) == Violations.of(Violation.TooShortString("hi", 10)))
       }
       test("fail on second validation") {
         val first: Validation[Violation, String, String]  = Validations.minLength(1)
         val second: Validation[Violation, String, String] = Validations.maxLength(2)
 
-        assertTrue((first >> second).run("hello") == Left(Violations.of(Violation.TooLongString("hello", 2))))
+        assertTrue((first >> second).run("hello").is(_.left) == Violations.of(Violation.TooLongString("hello", 2)))
       }
       test("does not run second validation when first fails") {
         var called = false
@@ -69,26 +69,26 @@ object ValidationCombinatorsSpec extends ZIOSpecDefault {
         val first: Validation[Violation, String, String]  = Validations.minLength(1)
         val second: Validation[Violation, String, String] = Validations.minLength(5)
 
-        assertTrue(first.orElse(second).run("ab") == Right("ab"))
+        assertTrue(first.orElse(second).run("ab").is(_.right) == "ab")
       }
       test("fall back to second when first fails") {
         val first: Validation[Violation, String, String]  = Validations.minLength(10)
         val second: Validation[Violation, String, String] = Validations.minLength(1)
 
-        assertTrue(first.orElse(second).run("hello") == Right("hello"))
+        assertTrue(first.orElse(second).run("hello").is(_.right) == "hello")
       }
       test("return first violation when both fail") {
         val first: Validation[Violation, String, String]  = Validations.minLength(10)
         val second: Validation[Violation, String, String] = Validations.maxLength(1)
 
-        assertTrue(first.orElse(second).run("hello") == Left(Violations.of(Violation.TooShortString("hello", 10))))
+        assertTrue(first.orElse(second).run("hello").is(_.left) == Violations.of(Violation.TooShortString("hello", 10)))
       }
       test("does not run second when first succeeds") {
         var called = false
         val first  = Validation.instance[String](s => Right(s))
         val second = Validation.instance[String] { _ => called = true; Right("fallback") }
         val result = first.orElse(second).run("ok")
-        assertTrue(result == Right("ok"), !called)
+        assertTrue(result.is(_.right) == "ok", !called)
       }
     }
   }

--- a/core/src/test/scala/yoshi/ValidationCombinatorsSpec.scala
+++ b/core/src/test/scala/yoshi/ValidationCombinatorsSpec.scala
@@ -2,8 +2,6 @@ package yoshi
 
 import yoshi.Validation.*
 import yoshi.defaults.*
-import zio.Promise
-import zio.ZIO
 import zio.test.*
 
 object ValidationCombinatorsSpec extends ZIOSpecDefault {
@@ -18,92 +16,79 @@ object ValidationCombinatorsSpec extends ZIOSpecDefault {
           ),
         )
 
-        for result <- validation.run("ab").either
-        yield assertTrue(result.is(_.left) == expectedViolations)
+        assertTrue(validation.run("ab") == Left(expectedViolations))
       }
       test("result value when valid") {
         val validation = (Validations.minLength(1) |+| Validations.maxLength(2))
           .map(_.length)
 
-        for result <- validation.run("ab")
-        yield assertTrue(result == 2)
+        assertTrue(validation.run("ab") == Right(2))
       }
       test("return left value when both succeed") {
-        val left: Validation[Any, Violation, String, String] =
-          Validation.instance[String](s => ZIO.succeed(s.toUpperCase))
-        val right: Validation[Any, Violation, String, String] =
-          Validation.instance[String](s => ZIO.succeed(s.toLowerCase))
+        val left: Validation[Violation, String, String] =
+          Validation.instance[String](s => Right(s.toUpperCase))
+        val right: Validation[Violation, String, String] =
+          Validation.instance[String](s => Right(s.toLowerCase))
 
-        for result <- (left |+| right).run("Ab")
-        yield assertTrue(result == "AB")
+        assertTrue((left |+| right).run("Ab") == Right("AB"))
       }
     }
     suiteAll(">>") {
       test("chain two validations sequentially") {
-        val first: Validation[Any, Violation, String, String] = Validations.minLength(1)
-        val second: Validation[Any, Violation, String, Int]   = Validation.instance[String] { s =>
-          ZIO.succeed(s.length)
+        val first: Validation[Violation, String, String] = Validations.minLength(1)
+        val second: Validation[Violation, String, Int]   = Validation.instance[String] { s =>
+          Right(s.length)
         }
 
-        for result <- (first >> second).run("hello")
-        yield assertTrue(result == 5)
+        assertTrue((first >> second).run("hello") == Right(5))
       }
       test("fail on first validation") {
-        val first: Validation[Any, Violation, String, String] = Validations.minLength(10)
-        val second: Validation[Any, Violation, String, Int]   = Validation.instance[String] { s =>
-          ZIO.succeed(s.length)
+        val first: Validation[Violation, String, String] = Validations.minLength(10)
+        val second: Validation[Violation, String, Int]   = Validation.instance[String] { s =>
+          Right(s.length)
         }
 
-        for result <- (first >> second).run("hi").either
-        yield assertTrue(result.is(_.left) == Violations.of(Violation.TooShortString("hi", 10)))
+        assertTrue((first >> second).run("hi") == Left(Violations.of(Violation.TooShortString("hi", 10))))
       }
       test("fail on second validation") {
-        val first: Validation[Any, Violation, String, String]  = Validations.minLength(1)
-        val second: Validation[Any, Violation, String, String] = Validations.maxLength(2)
+        val first: Validation[Violation, String, String]  = Validations.minLength(1)
+        val second: Validation[Violation, String, String] = Validations.maxLength(2)
 
-        for result <- (first >> second).run("hello").either
-        yield assertTrue(result.is(_.left) == Violations.of(Violation.TooLongString("hello", 2)))
+        assertTrue((first >> second).run("hello") == Left(Violations.of(Violation.TooLongString("hello", 2))))
       }
       test("does not run second validation when first fails") {
-        for
-          called <- Promise.make[Nothing, Unit]
-          first  = Validations.minLength(10)
-          second = Validation.instance[String](_ => called.succeed(()) *> ZIO.succeed(0))
-          _         <- (first >> second).run("hi").either
-          wasCalled <- called.isDone
-        yield assertTrue(!wasCalled)
+        var called = false
+        val first  = Validations.minLength(10)
+        val second = Validation.instance[String] { _ => called = true; Right(0) }
+        val _      = (first >> second).run("hi")
+        assertTrue(!called)
       }
     }
     suiteAll("orElse") {
       test("return first result when first succeeds") {
-        val first: Validation[Any, Violation, String, String]  = Validations.minLength(1)
-        val second: Validation[Any, Violation, String, String] = Validations.minLength(5)
+        val first: Validation[Violation, String, String]  = Validations.minLength(1)
+        val second: Validation[Violation, String, String] = Validations.minLength(5)
 
-        for result <- first.orElse(second).run("ab")
-        yield assertTrue(result == "ab")
+        assertTrue(first.orElse(second).run("ab") == Right("ab"))
       }
       test("fall back to second when first fails") {
-        val first: Validation[Any, Violation, String, String]  = Validations.minLength(10)
-        val second: Validation[Any, Violation, String, String] = Validations.minLength(1)
+        val first: Validation[Violation, String, String]  = Validations.minLength(10)
+        val second: Validation[Violation, String, String] = Validations.minLength(1)
 
-        for result <- first.orElse(second).run("hello")
-        yield assertTrue(result == "hello")
+        assertTrue(first.orElse(second).run("hello") == Right("hello"))
       }
       test("return first violation when both fail") {
-        val first: Validation[Any, Violation, String, String]  = Validations.minLength(10)
-        val second: Validation[Any, Violation, String, String] = Validations.maxLength(1)
+        val first: Validation[Violation, String, String]  = Validations.minLength(10)
+        val second: Validation[Violation, String, String] = Validations.maxLength(1)
 
-        for result <- first.orElse(second).run("hello").either
-        yield assertTrue(result.is(_.left) == Violations.of(Violation.TooShortString("hello", 10)))
+        assertTrue(first.orElse(second).run("hello") == Left(Violations.of(Violation.TooShortString("hello", 10))))
       }
       test("does not run second when first succeeds") {
-        for
-          called <- Promise.make[Nothing, Unit]
-          first  = Validation.instance[String](s => ZIO.succeed(s))
-          second = Validation.instance[String](_ => called.succeed(()) *> ZIO.succeed("fallback"))
-          result    <- first.orElse(second).run("ok")
-          wasCalled <- called.isDone
-        yield assertTrue(result == "ok", !wasCalled)
+        var called = false
+        val first  = Validation.instance[String](s => Right(s))
+        val second = Validation.instance[String] { _ => called = true; Right("fallback") }
+        val result = first.orElse(second).run("ok")
+        assertTrue(result == Right("ok"), !called)
       }
     }
   }

--- a/core/src/test/scala/yoshi/ValidationProductSpec.scala
+++ b/core/src/test/scala/yoshi/ValidationProductSpec.scala
@@ -77,7 +77,7 @@ object ValidationProductSpec extends ZIOSpecDefault {
           ),
         )
 
-        assertTrue(validation.run(invalid) == Left(expectedViolations))
+        assertTrue(validation.run(invalid).is(_.left) == expectedViolations)
       }
       test("result transformed object when valid") {
         val valid = Dirty(
@@ -110,7 +110,7 @@ object ValidationProductSpec extends ZIOSpecDefault {
           ),
         )
 
-        assertTrue(validation.run(valid) == Right(expectedObject))
+        assertTrue(validation.run(valid).is(_.right) == expectedObject)
       }
     }
   }

--- a/core/src/test/scala/yoshi/ValidationProductSpec.scala
+++ b/core/src/test/scala/yoshi/ValidationProductSpec.scala
@@ -110,7 +110,11 @@ object ValidationProductSpec extends ZIOSpecDefault {
           ),
         )
 
-        assertTrue(validation.run(valid).is(_.right) == expectedObject)
+        for {
+          result <- validation.run(valid)
+        } yield {
+          assertTrue(result == expectedObject)
+        }
       }
     }
   }

--- a/core/src/test/scala/yoshi/ValidationProductSpec.scala
+++ b/core/src/test/scala/yoshi/ValidationProductSpec.scala
@@ -3,11 +3,10 @@ package yoshi
 import yoshi.Validation.*
 import yoshi.Violations.Path
 import yoshi.defaults.*
-import zio.Promise
 import zio.test.*
 
 object ValidationProductSpec extends ZIOSpecDefault {
-  given childValidation: Validation[Any, Violation, Dirty.Child, Clean.Child] =
+  given childValidation: Validation[Violation, Dirty.Child, Clean.Child] =
     Validation.instance[Dirty.Child] { dirty =>
       (
         dirty.name.validateAs[String].at("name")
@@ -16,7 +15,7 @@ object ValidationProductSpec extends ZIOSpecDefault {
       }
     }
 
-  val validation: Validation[Any, Violation, Dirty, Clean] =
+  val validation: Validation[Violation, Dirty, Clean] =
     Validation.instance[Dirty] { dirty =>
       (
         dirty.a1.validateAs[String].at("a1"),
@@ -78,8 +77,7 @@ object ValidationProductSpec extends ZIOSpecDefault {
           ),
         )
 
-        for result <- validation.run(invalid).either
-        yield assertTrue(result.is(_.left) == expectedViolations)
+        assertTrue(validation.run(invalid) == Left(expectedViolations))
       }
       test("result transformed object when valid") {
         val valid = Dirty(
@@ -112,18 +110,7 @@ object ValidationProductSpec extends ZIOSpecDefault {
           ),
         )
 
-        for result <- validation.run(valid)
-        yield assertTrue(result == expectedObject)
-      }
-    }
-    suiteAll("parallelism") {
-      test("validateN runs validations in parallel") {
-        for
-          gate <- Promise.make[Nothing, Unit]
-          v1 = Validation.instance[Unit](_ => gate.await.as("v1"))
-          v2 = Validation.instance[Unit](_ => gate.succeed(()).as("v2"))
-          result <- (v1.run(()), v2.run(())).validateN { case (a, b) => (a, b) }
-        yield assertTrue(result == ("v1", "v2"))
+        assertTrue(validation.run(valid) == Right(expectedObject))
       }
     }
   }

--- a/core/src/test/scala/yoshi/ValidationTransformsSpec.scala
+++ b/core/src/test/scala/yoshi/ValidationTransformsSpec.scala
@@ -7,15 +7,27 @@ object ValidationTransformsSpec extends ZIOSpecDefault {
   override def spec = suiteAll("Validation transforms") {
     suiteAll("succeed") {
       test("returns the input unchanged") {
-        assertTrue(Validation.succeed[String].run("hello").is(_.right) == "hello")
+        for {
+          result <- Validation.succeed[String].run("hello")
+        } yield {
+          assertTrue(result == "hello")
+        }
       }
       test("is right identity for >>") {
         val v = Validations.minLength(1)
-        assertTrue((v >> Validation.succeed).run("ab").is(_.right) == "ab")
+        for {
+          result <- (v >> Validation.succeed).run("ab")
+        } yield {
+          assertTrue(result == "ab")
+        }
       }
       test("is left identity for >>") {
         val v = Validations.minLength(1)
-        assertTrue((Validation.succeed >> v).run("ab").is(_.right) == "ab")
+        for {
+          result <- (Validation.succeed >> v).run("ab")
+        } yield {
+          assertTrue(result == "ab")
+        }
       }
     }
     suiteAll("fail") {
@@ -30,7 +42,11 @@ object ValidationTransformsSpec extends ZIOSpecDefault {
         val nameValidation: Validation[Violation, NameInput, String] =
           nonEmpty.contramap(_.name.getOrElse(""))
 
-        assertTrue(nameValidation.run(NameInput(name = Some("Alice"))).is(_.right) == "Alice")
+        for {
+          result <- nameValidation.run(NameInput(name = Some("Alice")))
+        } yield {
+          assertTrue(result == "Alice")
+        }
       }
       test("propagate violations from adapted input") {
         val minLength3: Validation[Violation, String, String]        = Validations.minLength(3)
@@ -49,7 +65,11 @@ object ValidationTransformsSpec extends ZIOSpecDefault {
       test("preserve success value") {
         val v = Validations.minLength(1).mapError(_.toString)
 
-        assertTrue(v.run("hello").is(_.right) == "hello")
+        for {
+          result <- v.run("hello")
+        } yield {
+          assertTrue(result == "hello")
+        }
       }
       test("transform nested violations preserving structure") {
         val v = Validation
@@ -99,11 +119,19 @@ object ValidationTransformsSpec extends ZIOSpecDefault {
     suiteAll("optional") {
       test("pass through None as success") {
         val v = Validations.minLength(3).optional
-        assertTrue(v.run(None).is(_.right) == None)
+        for {
+          result <- v.run(None)
+        } yield {
+          assertTrue(result == None)
+        }
       }
       test("validate Some value and wrap result in Some") {
         val v = Validations.minLength(3).optional
-        assertTrue(v.run(Some("hello")).is(_.right) == Some("hello"))
+        for {
+          result <- v.run(Some("hello"))
+        } yield {
+          assertTrue(result == Some("hello"))
+        }
       }
       test("fail when Some value is invalid") {
         val v = Validations.minLength(3).optional
@@ -111,11 +139,19 @@ object ValidationTransformsSpec extends ZIOSpecDefault {
       }
       test("compose with map") {
         val v = Validations.minLength(1).optional.map(_.map(_.length))
-        assertTrue(v.run(Some("hello")).is(_.right) == Some(5))
+        for {
+          result <- v.run(Some("hello"))
+        } yield {
+          assertTrue(result == Some(5))
+        }
       }
       test("compose with sequential >>") {
         val v = (Validations.minLength(1) >> Validations.maxLength(5)).optional
-        assertTrue(v.run(Some("abc")).is(_.right) == Some("abc"))
+        for {
+          result <- v.run(Some("abc"))
+        } yield {
+          assertTrue(result == Some("abc"))
+        }
       }
       test("fail in sequential >> composition") {
         val v = (Validations.minLength(1) >> Validations.maxLength(3)).optional

--- a/core/src/test/scala/yoshi/ValidationTransformsSpec.scala
+++ b/core/src/test/scala/yoshi/ValidationTransformsSpec.scala
@@ -1,70 +1,60 @@
 package yoshi
 
 import yoshi.defaults.*
-import zio.Promise
-import zio.ZIO
 import zio.test.*
 
 object ValidationTransformsSpec extends ZIOSpecDefault {
   override def spec = suiteAll("Validation transforms") {
     suiteAll("succeed") {
       test("returns the input unchanged") {
-        for result <- Validation.succeed[String].run("hello")
-        yield assertTrue(result == "hello")
+        assertTrue(Validation.succeed[String].run("hello") == Right("hello"))
       }
       test("is right identity for >>") {
         val v = Validations.minLength(1)
-        for result <- (v >> Validation.succeed).run("ab")
-        yield assertTrue(result == "ab")
+        assertTrue((v >> Validation.succeed).run("ab") == Right("ab"))
       }
       test("is left identity for >>") {
         val v = Validations.minLength(1)
-        for result <- (Validation.succeed >> v).run("ab")
-        yield assertTrue(result == "ab")
+        assertTrue((Validation.succeed >> v).run("ab") == Right("ab"))
       }
     }
     suiteAll("fail") {
       test("always fails with the given violation") {
         val v = Validation.fail[Violation](Violation.Required)
-        for result <- v.run("anything").either
-        yield assertTrue(result.is(_.left) == Violations.of[Violation](Violation.Required))
+        assertTrue(v.run("anything") == Left(Violations.of[Violation](Violation.Required)))
       }
     }
     suiteAll("contramap") {
       test("adapt input type before validation") {
-        val nonEmpty: Validation[Any, Violation, String, String]          = Validations.minLength(1)
-        val nameValidation: Validation[Any, Violation, NameInput, String] =
+        val nonEmpty: Validation[Violation, String, String]          = Validations.minLength(1)
+        val nameValidation: Validation[Violation, NameInput, String] =
           nonEmpty.contramap(_.name.getOrElse(""))
 
-        for result <- nameValidation.run(NameInput(name = Some("Alice")))
-        yield assertTrue(result == "Alice")
+        assertTrue(nameValidation.run(NameInput(name = Some("Alice"))) == Right("Alice"))
       }
       test("propagate violations from adapted input") {
-        val minLength3: Validation[Any, Violation, String, String]        = Validations.minLength(3)
-        val nameValidation: Validation[Any, Violation, NameInput, String] =
+        val minLength3: Validation[Violation, String, String]        = Validations.minLength(3)
+        val nameValidation: Validation[Violation, NameInput, String] =
           minLength3.contramap(_.name.getOrElse(""))
 
-        for result <- nameValidation.run(NameInput(name = Some("ab"))).either
-        yield assertTrue(result.is(_.left) == Violations(Vector(Violation.TooShortString("ab", 3))))
+        assertTrue(nameValidation.run(NameInput(name = Some("ab"))) == Left(Violations(Vector(Violation.TooShortString("ab", 3)))))
       }
     }
     suiteAll("mapError") {
       test("transform error type on failure") {
         val v = Validations.minLength(3).mapError(_.toString)
 
-        for result <- v.run("ab").either
-        yield assertTrue(result.is(_.left) == Violations.of(Violation.TooShortString("ab", 3).toString))
+        assertTrue(v.run("ab") == Left(Violations.of(Violation.TooShortString("ab", 3).toString)))
       }
       test("preserve success value") {
         val v = Validations.minLength(1).mapError(_.toString)
 
-        for result <- v.run("hello")
-        yield assertTrue(result == "hello")
+        assertTrue(v.run("hello") == Right("hello"))
       }
       test("transform nested violations preserving structure") {
         val v = Validation
           .instance[String] { s =>
-            ZIO.fail(
+            Left(
               Violations[Violation](
                 values = Vector(Violation.Required),
                 children = Map(
@@ -75,33 +65,34 @@ object ValidationTransformsSpec extends ZIOSpecDefault {
           }
           .mapError(_.toString)
 
-        for result <- v.run("ab").either
-        yield assertTrue(
-          result.is(_.left) == Violations[String](
-            values = Vector(Violation.Required.toString),
-            children = Map(
-              Violations.Path("child") -> Violations.of(Violation.TooShortString("ab", 3).toString),
+        assertTrue(
+          v.run("ab") == Left(
+            Violations[String](
+              values = Vector(Violation.Required.toString),
+              children = Map(
+                Violations.Path("child") -> Violations.of(Violation.TooShortString("ab", 3).toString),
+              ),
             ),
           ),
         )
       }
       test("compose with >>") {
-        val first: Validation[Any, Violation, String, String]  = Validations.minLength(1)
-        val second: Validation[Any, Violation, String, String] = Validations.maxLength(3)
-        val v                                                  = (first >> second).mapError(_.toString)
+        val first: Validation[Violation, String, String]  = Validations.minLength(1)
+        val second: Validation[Violation, String, String] = Validations.maxLength(3)
+        val v                                             = (first >> second).mapError(_.toString)
 
-        for result <- v.run("hello").either
-        yield assertTrue(result.is(_.left) == Violations.of(Violation.TooLongString("hello", 3).toString))
+        assertTrue(v.run("hello") == Left(Violations.of(Violation.TooLongString("hello", 3).toString)))
       }
       test("compose with |+|") {
         val v = (Validations.minLength(3) |+| Validations.maxLength(1)).mapError(_.toString)
 
-        for result <- v.run("ab").either
-        yield assertTrue(
-          result.is(_.left) == Violations(
-            Vector(
-              Violation.TooShortString("ab", 3).toString,
-              Violation.TooLongString("ab", 1).toString,
+        assertTrue(
+          v.run("ab") == Left(
+            Violations(
+              Vector(
+                Violation.TooShortString("ab", 3).toString,
+                Violation.TooLongString("ab", 1).toString,
+              ),
             ),
           ),
         )
@@ -110,41 +101,33 @@ object ValidationTransformsSpec extends ZIOSpecDefault {
     suiteAll("optional") {
       test("pass through None as success") {
         val v = Validations.minLength(3).optional
-        for result <- v.run(None)
-        yield assertTrue(result == None)
+        assertTrue(v.run(None) == Right(None))
       }
       test("validate Some value and wrap result in Some") {
         val v = Validations.minLength(3).optional
-        for result <- v.run(Some("hello"))
-        yield assertTrue(result == Some("hello"))
+        assertTrue(v.run(Some("hello")) == Right(Some("hello")))
       }
       test("fail when Some value is invalid") {
         val v = Validations.minLength(3).optional
-        for result <- v.run(Some("ab")).either
-        yield assertTrue(result.is(_.left) == Violations.of(Violation.TooShortString("ab", 3)))
+        assertTrue(v.run(Some("ab")) == Left(Violations.of(Violation.TooShortString("ab", 3))))
       }
       test("compose with map") {
         val v = Validations.minLength(1).optional.map(_.map(_.length))
-        for result <- v.run(Some("hello"))
-        yield assertTrue(result == Some(5))
+        assertTrue(v.run(Some("hello")) == Right(Some(5)))
       }
       test("compose with sequential >>") {
         val v = (Validations.minLength(1) >> Validations.maxLength(5)).optional
-        for result <- v.run(Some("abc"))
-        yield assertTrue(result == Some("abc"))
+        assertTrue(v.run(Some("abc")) == Right(Some("abc")))
       }
       test("fail in sequential >> composition") {
         val v = (Validations.minLength(1) >> Validations.maxLength(3)).optional
-        for result <- v.run(Some("hello")).either
-        yield assertTrue(result.is(_.left) == Violations.of(Violation.TooLongString("hello", 3)))
+        assertTrue(v.run(Some("hello")) == Left(Violations.of(Violation.TooLongString("hello", 3))))
       }
       test("does not run underlying validation for None") {
-        for
-          called <- Promise.make[Nothing, Unit]
-          raw = Validation.instance[String](_ => called.succeed(()) *> ZIO.succeed("ok"))
-          _         <- raw.optional.run(None)
-          wasCalled <- called.isDone
-        yield assertTrue(!wasCalled)
+        var called = false
+        val raw    = Validation.instance[String] { _ => called = true; Right("ok") }
+        val _      = raw.optional.run(None)
+        assertTrue(!called)
       }
     }
   }

--- a/core/src/test/scala/yoshi/ValidationTransformsSpec.scala
+++ b/core/src/test/scala/yoshi/ValidationTransformsSpec.scala
@@ -7,21 +7,21 @@ object ValidationTransformsSpec extends ZIOSpecDefault {
   override def spec = suiteAll("Validation transforms") {
     suiteAll("succeed") {
       test("returns the input unchanged") {
-        assertTrue(Validation.succeed[String].run("hello") == Right("hello"))
+        assertTrue(Validation.succeed[String].run("hello").is(_.right) == "hello")
       }
       test("is right identity for >>") {
         val v = Validations.minLength(1)
-        assertTrue((v >> Validation.succeed).run("ab") == Right("ab"))
+        assertTrue((v >> Validation.succeed).run("ab").is(_.right) == "ab")
       }
       test("is left identity for >>") {
         val v = Validations.minLength(1)
-        assertTrue((Validation.succeed >> v).run("ab") == Right("ab"))
+        assertTrue((Validation.succeed >> v).run("ab").is(_.right) == "ab")
       }
     }
     suiteAll("fail") {
       test("always fails with the given violation") {
         val v = Validation.fail[Violation](Violation.Required)
-        assertTrue(v.run("anything") == Left(Violations.of[Violation](Violation.Required)))
+        assertTrue(v.run("anything").is(_.left) == Violations.of[Violation](Violation.Required))
       }
     }
     suiteAll("contramap") {
@@ -30,26 +30,26 @@ object ValidationTransformsSpec extends ZIOSpecDefault {
         val nameValidation: Validation[Violation, NameInput, String] =
           nonEmpty.contramap(_.name.getOrElse(""))
 
-        assertTrue(nameValidation.run(NameInput(name = Some("Alice"))) == Right("Alice"))
+        assertTrue(nameValidation.run(NameInput(name = Some("Alice"))).is(_.right) == "Alice")
       }
       test("propagate violations from adapted input") {
         val minLength3: Validation[Violation, String, String]        = Validations.minLength(3)
         val nameValidation: Validation[Violation, NameInput, String] =
           minLength3.contramap(_.name.getOrElse(""))
 
-        assertTrue(nameValidation.run(NameInput(name = Some("ab"))) == Left(Violations(Vector(Violation.TooShortString("ab", 3)))))
+        assertTrue(nameValidation.run(NameInput(name = Some("ab"))).is(_.left) == Violations(Vector(Violation.TooShortString("ab", 3))))
       }
     }
     suiteAll("mapError") {
       test("transform error type on failure") {
         val v = Validations.minLength(3).mapError(_.toString)
 
-        assertTrue(v.run("ab") == Left(Violations.of(Violation.TooShortString("ab", 3).toString)))
+        assertTrue(v.run("ab").is(_.left) == Violations.of(Violation.TooShortString("ab", 3).toString))
       }
       test("preserve success value") {
         val v = Validations.minLength(1).mapError(_.toString)
 
-        assertTrue(v.run("hello") == Right("hello"))
+        assertTrue(v.run("hello").is(_.right) == "hello")
       }
       test("transform nested violations preserving structure") {
         val v = Validation
@@ -66,14 +66,13 @@ object ValidationTransformsSpec extends ZIOSpecDefault {
           .mapError(_.toString)
 
         assertTrue(
-          v.run("ab") == Left(
+          v.run("ab").is(_.left) ==
             Violations[String](
               values = Vector(Violation.Required.toString),
               children = Map(
                 Violations.Path("child") -> Violations.of(Violation.TooShortString("ab", 3).toString),
               ),
             ),
-          ),
         )
       }
       test("compose with >>") {
@@ -81,47 +80,46 @@ object ValidationTransformsSpec extends ZIOSpecDefault {
         val second: Validation[Violation, String, String] = Validations.maxLength(3)
         val v                                             = (first >> second).mapError(_.toString)
 
-        assertTrue(v.run("hello") == Left(Violations.of(Violation.TooLongString("hello", 3).toString)))
+        assertTrue(v.run("hello").is(_.left) == Violations.of(Violation.TooLongString("hello", 3).toString))
       }
       test("compose with |+|") {
         val v = (Validations.minLength(3) |+| Validations.maxLength(1)).mapError(_.toString)
 
         assertTrue(
-          v.run("ab") == Left(
+          v.run("ab").is(_.left) ==
             Violations(
               Vector(
                 Violation.TooShortString("ab", 3).toString,
                 Violation.TooLongString("ab", 1).toString,
               ),
             ),
-          ),
         )
       }
     }
     suiteAll("optional") {
       test("pass through None as success") {
         val v = Validations.minLength(3).optional
-        assertTrue(v.run(None) == Right(None))
+        assertTrue(v.run(None).is(_.right) == None)
       }
       test("validate Some value and wrap result in Some") {
         val v = Validations.minLength(3).optional
-        assertTrue(v.run(Some("hello")) == Right(Some("hello")))
+        assertTrue(v.run(Some("hello")).is(_.right) == Some("hello"))
       }
       test("fail when Some value is invalid") {
         val v = Validations.minLength(3).optional
-        assertTrue(v.run(Some("ab")) == Left(Violations.of(Violation.TooShortString("ab", 3))))
+        assertTrue(v.run(Some("ab")).is(_.left) == Violations.of(Violation.TooShortString("ab", 3)))
       }
       test("compose with map") {
         val v = Validations.minLength(1).optional.map(_.map(_.length))
-        assertTrue(v.run(Some("hello")) == Right(Some(5)))
+        assertTrue(v.run(Some("hello")).is(_.right) == Some(5))
       }
       test("compose with sequential >>") {
         val v = (Validations.minLength(1) >> Validations.maxLength(5)).optional
-        assertTrue(v.run(Some("abc")) == Right(Some("abc")))
+        assertTrue(v.run(Some("abc")).is(_.right) == Some("abc"))
       }
       test("fail in sequential >> composition") {
         val v = (Validations.minLength(1) >> Validations.maxLength(3)).optional
-        assertTrue(v.run(Some("hello")) == Left(Violations.of(Violation.TooLongString("hello", 3))))
+        assertTrue(v.run(Some("hello")).is(_.left) == Violations.of(Violation.TooLongString("hello", 3)))
       }
       test("does not run underlying validation for None") {
         var called = false

--- a/core/src/test/scala/yoshi/ValidationTypeclassSpec.scala
+++ b/core/src/test/scala/yoshi/ValidationTypeclassSpec.scala
@@ -11,19 +11,19 @@ object ValidationTypeclassSpec extends ZIOSpecDefault {
         given Validation[Violation, String, String] = Validations.minLength(1)
         val v                                       = summon[Validation[Violation, Option[String], Option[String]]]
 
-        assertTrue(v.run(Some("hello")) == Right(Some("hello")))
+        assertTrue(v.run(Some("hello")).is(_.right) == Some("hello"))
       }
       test("pass through None") {
         given Validation[Violation, String, String] = Validations.minLength(1)
         val v                                       = summon[Validation[Violation, Option[String], Option[String]]]
 
-        assertTrue(v.run(None) == Right(None))
+        assertTrue(v.run(None).is(_.right) == None)
       }
       test("fail when Some value is invalid") {
         given Validation[Violation, String, String] = Validations.minLength(5)
         val v                                       = summon[Validation[Violation, Option[String], Option[String]]]
 
-        assertTrue(v.run(Some("ab")) == Left(Violations.of(Violation.TooShortString("ab", 5))))
+        assertTrue(v.run(Some("ab")).is(_.left) == Violations.of(Violation.TooShortString("ab", 5)))
       }
     }
     suiteAll("seqCanBeValidatedAs") {
@@ -31,13 +31,13 @@ object ValidationTypeclassSpec extends ZIOSpecDefault {
         given Validation[Violation, String, String] = Validations.minLength(1)
         val v                                       = summon[Validation[Violation, Seq[String], Seq[String]]]
 
-        assertTrue(v.run(Seq("a", "bb", "ccc")) == Right(Seq("a", "bb", "ccc")))
+        assertTrue(v.run(Seq("a", "bb", "ccc")).is(_.right) == Seq("a", "bb", "ccc"))
       }
       test("succeed with empty Seq") {
         given Validation[Violation, String, String] = Validations.minLength(1)
         val v                                       = summon[Validation[Violation, Seq[String], Seq[String]]]
 
-        assertTrue(v.run(Seq.empty) == Right(Seq.empty))
+        assertTrue(v.run(Seq.empty).is(_.right) == Seq.empty)
       }
       test("accumulate violations with indices") {
         given Validation[Violation, String, String] = Validations.minLength(3)
@@ -50,7 +50,7 @@ object ValidationTypeclassSpec extends ZIOSpecDefault {
           ),
         )
 
-        assertTrue(v.run(Seq("ab", "hello", "x")) == Left(expectedViolations))
+        assertTrue(v.run(Seq("ab", "hello", "x")).is(_.left) == expectedViolations)
       }
     }
     suiteAll("listCanBeValidatedAs") {
@@ -58,7 +58,7 @@ object ValidationTypeclassSpec extends ZIOSpecDefault {
         given Validation[Violation, String, String] = Validations.minLength(1)
         val v                                       = summon[Validation[Violation, List[String], List[String]]]
 
-        assertTrue(v.run(List("a", "bb", "ccc")) == Right(List("a", "bb", "ccc")))
+        assertTrue(v.run(List("a", "bb", "ccc")).is(_.right) == List("a", "bb", "ccc"))
       }
       test("accumulate violations with indices") {
         given Validation[Violation, String, String] = Validations.minLength(3)
@@ -71,7 +71,7 @@ object ValidationTypeclassSpec extends ZIOSpecDefault {
           ),
         )
 
-        assertTrue(v.run(List("ab", "hello", "x")) == Left(expectedViolations))
+        assertTrue(v.run(List("ab", "hello", "x")).is(_.left) == expectedViolations)
       }
     }
     suiteAll("mapCanBeValidatedAs") {
@@ -83,7 +83,7 @@ object ValidationTypeclassSpec extends ZIOSpecDefault {
           "b" -> "yy",
         )
 
-        assertTrue(v.run(input) == Right(input))
+        assertTrue(v.run(input).is(_.right) == input)
       }
       test("accumulate violations with keys") {
         given Validation[Violation, String, String] = Validations.minLength(3)
@@ -96,7 +96,7 @@ object ValidationTypeclassSpec extends ZIOSpecDefault {
           ),
         )
 
-        assertTrue(v.run(Map("a" -> "ab", "b" -> "hello", "c" -> "x")) == Left(expectedViolations))
+        assertTrue(v.run(Map("a" -> "ab", "b" -> "hello", "c" -> "x")).is(_.left) == expectedViolations)
       }
     }
   }

--- a/core/src/test/scala/yoshi/ValidationTypeclassSpec.scala
+++ b/core/src/test/scala/yoshi/ValidationTypeclassSpec.scala
@@ -11,13 +11,21 @@ object ValidationTypeclassSpec extends ZIOSpecDefault {
         given Validation[Violation, String, String] = Validations.minLength(1)
         val v                                       = summon[Validation[Violation, Option[String], Option[String]]]
 
-        assertTrue(v.run(Some("hello")).is(_.right) == Some("hello"))
+        for {
+          result <- v.run(Some("hello"))
+        } yield {
+          assertTrue(result == Some("hello"))
+        }
       }
       test("pass through None") {
         given Validation[Violation, String, String] = Validations.minLength(1)
         val v                                       = summon[Validation[Violation, Option[String], Option[String]]]
 
-        assertTrue(v.run(None).is(_.right) == None)
+        for {
+          result <- v.run(None)
+        } yield {
+          assertTrue(result == None)
+        }
       }
       test("fail when Some value is invalid") {
         given Validation[Violation, String, String] = Validations.minLength(5)
@@ -31,13 +39,21 @@ object ValidationTypeclassSpec extends ZIOSpecDefault {
         given Validation[Violation, String, String] = Validations.minLength(1)
         val v                                       = summon[Validation[Violation, Seq[String], Seq[String]]]
 
-        assertTrue(v.run(Seq("a", "bb", "ccc")).is(_.right) == Seq("a", "bb", "ccc"))
+        for {
+          result <- v.run(Seq("a", "bb", "ccc"))
+        } yield {
+          assertTrue(result == Seq("a", "bb", "ccc"))
+        }
       }
       test("succeed with empty Seq") {
         given Validation[Violation, String, String] = Validations.minLength(1)
         val v                                       = summon[Validation[Violation, Seq[String], Seq[String]]]
 
-        assertTrue(v.run(Seq.empty).is(_.right) == Seq.empty)
+        for {
+          result <- v.run(Seq.empty)
+        } yield {
+          assertTrue(result == Seq.empty)
+        }
       }
       test("accumulate violations with indices") {
         given Validation[Violation, String, String] = Validations.minLength(3)
@@ -58,7 +74,11 @@ object ValidationTypeclassSpec extends ZIOSpecDefault {
         given Validation[Violation, String, String] = Validations.minLength(1)
         val v                                       = summon[Validation[Violation, List[String], List[String]]]
 
-        assertTrue(v.run(List("a", "bb", "ccc")).is(_.right) == List("a", "bb", "ccc"))
+        for {
+          result <- v.run(List("a", "bb", "ccc"))
+        } yield {
+          assertTrue(result == List("a", "bb", "ccc"))
+        }
       }
       test("accumulate violations with indices") {
         given Validation[Violation, String, String] = Validations.minLength(3)
@@ -83,7 +103,11 @@ object ValidationTypeclassSpec extends ZIOSpecDefault {
           "b" -> "yy",
         )
 
-        assertTrue(v.run(input).is(_.right) == input)
+        for {
+          result <- v.run(input)
+        } yield {
+          assertTrue(result == input)
+        }
       }
       test("accumulate violations with keys") {
         given Validation[Violation, String, String] = Validations.minLength(3)

--- a/core/src/test/scala/yoshi/ValidationTypeclassSpec.scala
+++ b/core/src/test/scala/yoshi/ValidationTypeclassSpec.scala
@@ -8,45 +8,40 @@ object ValidationTypeclassSpec extends ZIOSpecDefault {
   override def spec = suiteAll("Validation typeclass instances") {
     suiteAll("optionCanBeValidatedAs") {
       test("derive Option validation from given") {
-        given Validation[Any, Violation, String, String] = Validations.minLength(1)
-        val v                                            = summon[Validation[Any, Violation, Option[String], Option[String]]]
+        given Validation[Violation, String, String] = Validations.minLength(1)
+        val v                                       = summon[Validation[Violation, Option[String], Option[String]]]
 
-        for result <- v.run(Some("hello"))
-        yield assertTrue(result == Some("hello"))
+        assertTrue(v.run(Some("hello")) == Right(Some("hello")))
       }
       test("pass through None") {
-        given Validation[Any, Violation, String, String] = Validations.minLength(1)
-        val v                                            = summon[Validation[Any, Violation, Option[String], Option[String]]]
+        given Validation[Violation, String, String] = Validations.minLength(1)
+        val v                                       = summon[Validation[Violation, Option[String], Option[String]]]
 
-        for result <- v.run(None)
-        yield assertTrue(result == None)
+        assertTrue(v.run(None) == Right(None))
       }
       test("fail when Some value is invalid") {
-        given Validation[Any, Violation, String, String] = Validations.minLength(5)
-        val v                                            = summon[Validation[Any, Violation, Option[String], Option[String]]]
+        given Validation[Violation, String, String] = Validations.minLength(5)
+        val v                                       = summon[Validation[Violation, Option[String], Option[String]]]
 
-        for result <- v.run(Some("ab")).either
-        yield assertTrue(result.is(_.left) == Violations.of(Violation.TooShortString("ab", 5)))
+        assertTrue(v.run(Some("ab")) == Left(Violations.of(Violation.TooShortString("ab", 5))))
       }
     }
     suiteAll("seqCanBeValidatedAs") {
       test("validate all elements in Seq") {
-        given Validation[Any, Violation, String, String] = Validations.minLength(1)
-        val v                                            = summon[Validation[Any, Violation, Seq[String], Seq[String]]]
+        given Validation[Violation, String, String] = Validations.minLength(1)
+        val v                                       = summon[Validation[Violation, Seq[String], Seq[String]]]
 
-        for result <- v.run(Seq("a", "bb", "ccc"))
-        yield assertTrue(result == Seq("a", "bb", "ccc"))
+        assertTrue(v.run(Seq("a", "bb", "ccc")) == Right(Seq("a", "bb", "ccc")))
       }
       test("succeed with empty Seq") {
-        given Validation[Any, Violation, String, String] = Validations.minLength(1)
-        val v                                            = summon[Validation[Any, Violation, Seq[String], Seq[String]]]
+        given Validation[Violation, String, String] = Validations.minLength(1)
+        val v                                       = summon[Validation[Violation, Seq[String], Seq[String]]]
 
-        for result <- v.run(Seq.empty)
-        yield assertTrue(result == Seq.empty)
+        assertTrue(v.run(Seq.empty) == Right(Seq.empty))
       }
       test("accumulate violations with indices") {
-        given Validation[Any, Violation, String, String] = Validations.minLength(3)
-        val v                                            = summon[Validation[Any, Violation, Seq[String], Seq[String]]]
+        given Validation[Violation, String, String] = Validations.minLength(3)
+        val v                                       = summon[Validation[Violation, Seq[String], Seq[String]]]
 
         val expectedViolations = Violations[Violation](
           children = Map(
@@ -55,21 +50,19 @@ object ValidationTypeclassSpec extends ZIOSpecDefault {
           ),
         )
 
-        for result <- v.run(Seq("ab", "hello", "x")).either
-        yield assertTrue(result.is(_.left) == expectedViolations)
+        assertTrue(v.run(Seq("ab", "hello", "x")) == Left(expectedViolations))
       }
     }
     suiteAll("listCanBeValidatedAs") {
       test("validate all elements in List") {
-        given Validation[Any, Violation, String, String] = Validations.minLength(1)
-        val v                                            = summon[Validation[Any, Violation, List[String], List[String]]]
+        given Validation[Violation, String, String] = Validations.minLength(1)
+        val v                                       = summon[Validation[Violation, List[String], List[String]]]
 
-        for result <- v.run(List("a", "bb", "ccc"))
-        yield assertTrue(result == List("a", "bb", "ccc"))
+        assertTrue(v.run(List("a", "bb", "ccc")) == Right(List("a", "bb", "ccc")))
       }
       test("accumulate violations with indices") {
-        given Validation[Any, Violation, String, String] = Validations.minLength(3)
-        val v                                            = summon[Validation[Any, Violation, List[String], List[String]]]
+        given Validation[Violation, String, String] = Validations.minLength(3)
+        val v                                       = summon[Validation[Violation, List[String], List[String]]]
 
         val expectedViolations = Violations[Violation](
           children = Map(
@@ -78,25 +71,23 @@ object ValidationTypeclassSpec extends ZIOSpecDefault {
           ),
         )
 
-        for result <- v.run(List("ab", "hello", "x")).either
-        yield assertTrue(result.is(_.left) == expectedViolations)
+        assertTrue(v.run(List("ab", "hello", "x")) == Left(expectedViolations))
       }
     }
     suiteAll("mapCanBeValidatedAs") {
       test("validate all values in Map") {
-        given Validation[Any, Violation, String, String] = Validations.minLength(1)
-        val v                                            = summon[Validation[Any, Violation, Map[String, String], Map[String, String]]]
-        val input                                        = Map(
+        given Validation[Violation, String, String] = Validations.minLength(1)
+        val v                                       = summon[Validation[Violation, Map[String, String], Map[String, String]]]
+        val input                                   = Map(
           "a" -> "x",
           "b" -> "yy",
         )
 
-        for result <- v.run(input)
-        yield assertTrue(result == input)
+        assertTrue(v.run(input) == Right(input))
       }
       test("accumulate violations with keys") {
-        given Validation[Any, Violation, String, String] = Validations.minLength(3)
-        val v                                            = summon[Validation[Any, Violation, Map[String, String], Map[String, String]]]
+        given Validation[Violation, String, String] = Validations.minLength(3)
+        val v                                       = summon[Validation[Violation, Map[String, String], Map[String, String]]]
 
         val expectedViolations = Violations[Violation](
           children = Map(
@@ -105,8 +96,7 @@ object ValidationTypeclassSpec extends ZIOSpecDefault {
           ),
         )
 
-        for result <- v.run(Map("a" -> "ab", "b" -> "hello", "c" -> "x")).either
-        yield assertTrue(result.is(_.left) == expectedViolations)
+        assertTrue(v.run(Map("a" -> "ab", "b" -> "hello", "c" -> "x")) == Left(expectedViolations))
       }
     }
   }

--- a/core/src/test/scala/yoshi/ValidationsSpec.scala
+++ b/core/src/test/scala/yoshi/ValidationsSpec.scala
@@ -8,109 +8,79 @@ object ValidationsSpec extends ZIOSpecDefault {
     suiteAll("required() can extract from Option") {
       test("success") {
         val validation = Validations.required[String]
-
-        for result <- validation.run(Some("hello"))
-        yield assertTrue(result == "hello")
+        assertTrue(validation.run(Some("hello")) == Right("hello"))
       }
       test("failure") {
         val validation = Validations.required[String]
-
-        for result <- validation.run(None).either
-        yield assertTrue(result.is(_.left) == Violations.of(Violation.Required))
+        assertTrue(validation.run(None) == Left(Violations.of(Violation.Required)))
       }
     }
     suiteAll("parseInt() can parse string to int") {
       test("success") {
         val validation = Validations.parseInt
-
-        for result <- validation.run("42")
-        yield assertTrue(result == 42)
+        assertTrue(validation.run("42") == Right(42))
       }
       test("failure") {
         val validation = Validations.parseInt
-
-        for result <- validation.run("abc").either
-        yield assertTrue(result.is(_.left) == Violations.of(Violation.NonIntegerString("abc")))
+        assertTrue(validation.run("abc") == Left(Violations.of(Violation.NonIntegerString("abc"))))
       }
     }
     suiteAll("maxLength() can test string length") {
       test("success") {
         val validation = Validations.maxLength(max = 4)
         val value      = "a".repeat(4)
-
-        for result <- validation.run(value)
-        yield assertTrue(result == value)
+        assertTrue(validation.run(value) == Right(value))
       }
       test("failure") {
         val validation = Validations.maxLength(max = 4)
         val value      = "a".repeat(5)
-
-        for result <- validation.run(value).either
-        yield assertTrue(result.is(_.left) == Violations.of(Violation.TooLongString(value, maxLength = 4)))
+        assertTrue(validation.run(value) == Left(Violations.of(Violation.TooLongString(value, maxLength = 4))))
       }
     }
     suiteAll("minLength() can test string length") {
       test("success") {
         val validation = Validations.minLength(min = 4)
         val value      = "a".repeat(4)
-
-        for result <- validation.run(value)
-        yield assertTrue(result == value)
+        assertTrue(validation.run(value) == Right(value))
       }
       test("failure") {
         val validation = Validations.minLength(min = 4)
         val value      = "a".repeat(3)
-
-        for result <- validation.run(value).either
-        yield assertTrue(result.is(_.left) == Violations.of(Violation.TooShortString(value, minLength = 4)))
+        assertTrue(validation.run(value) == Left(Violations.of(Violation.TooShortString(value, minLength = 4))))
       }
     }
     suiteAll("min() can test minimum value") {
       test("success") {
         val validation = Validations.min(n = 5)
-
-        for result <- validation.run(5)
-        yield assertTrue(result == 5)
+        assertTrue(validation.run(5) == Right(5))
       }
       test("failure") {
         val validation = Validations.min(n = 5)
-
-        for result <- validation.run(4).either
-        yield assertTrue(result.is(_.left) == Violations.of(Violation.TooSmall(value = 4, min = 5)))
+        assertTrue(validation.run(4) == Left(Violations.of(Violation.TooSmall(value = 4, min = 5))))
       }
     }
     suiteAll("max() can test maximum value") {
       test("success") {
         val validation = Validations.max(n = 10)
-
-        for result <- validation.run(10)
-        yield assertTrue(result == 10)
+        assertTrue(validation.run(10) == Right(10))
       }
       test("failure") {
         val validation = Validations.max(n = 10)
-
-        for result <- validation.run(11).either
-        yield assertTrue(result.is(_.left) == Violations.of(Violation.TooLarge(value = 11, max = 10)))
+        assertTrue(validation.run(11) == Left(Violations.of(Violation.TooLarge(value = 11, max = 10))))
       }
     }
     suiteAll("positive() can test positive value") {
       test("success") {
         val validation = Validations.positive
-
-        for result <- validation.run(1)
-        yield assertTrue(result == 1)
+        assertTrue(validation.run(1) == Right(1))
       }
       test("failure with zero") {
         val validation = Validations.positive
-
-        for result <- validation.run(0).either
-        yield assertTrue(result.is(_.left) == Violations.of(Violation.NonPositive(value = 0)))
+        assertTrue(validation.run(0) == Left(Violations.of(Violation.NonPositive(value = 0))))
       }
       test("failure with negative") {
         val validation = Validations.positive
-
-        for result <- validation.run(-1).either
-        yield assertTrue(result.is(_.left) == Violations.of(Violation.NonPositive(value = -1)))
+        assertTrue(validation.run(-1) == Left(Violations.of(Violation.NonPositive(value = -1))))
       }
     }
     suiteAll("matches() can test with regex") {
@@ -118,17 +88,13 @@ object ValidationsSpec extends ZIOSpecDefault {
         val pattern    = "^abc$".r
         val validation = Validations.matches(pattern)
         val value      = "abc"
-
-        for result <- validation.run(value)
-        yield assertTrue(result == value)
+        assertTrue(validation.run(value) == Right(value))
       }
       test("failure") {
         val pattern    = "^abc$".r
         val validation = Validations.matches(pattern)
         val value      = "abcd"
-
-        for result <- validation.run(value).either
-        yield assertTrue(result.is(_.left) == Violations.of(Violation.Unmatched(value, pattern)))
+        assertTrue(validation.run(value) == Left(Violations.of(Violation.Unmatched(value, pattern))))
       }
     }
   }

--- a/core/src/test/scala/yoshi/ValidationsSpec.scala
+++ b/core/src/test/scala/yoshi/ValidationsSpec.scala
@@ -8,79 +8,79 @@ object ValidationsSpec extends ZIOSpecDefault {
     suiteAll("required() can extract from Option") {
       test("success") {
         val validation = Validations.required[String]
-        assertTrue(validation.run(Some("hello")) == Right("hello"))
+        assertTrue(validation.run(Some("hello")).is(_.right) == "hello")
       }
       test("failure") {
         val validation = Validations.required[String]
-        assertTrue(validation.run(None) == Left(Violations.of(Violation.Required)))
+        assertTrue(validation.run(None).is(_.left) == Violations.of(Violation.Required))
       }
     }
     suiteAll("parseInt() can parse string to int") {
       test("success") {
         val validation = Validations.parseInt
-        assertTrue(validation.run("42") == Right(42))
+        assertTrue(validation.run("42").is(_.right) == 42)
       }
       test("failure") {
         val validation = Validations.parseInt
-        assertTrue(validation.run("abc") == Left(Violations.of(Violation.NonIntegerString("abc"))))
+        assertTrue(validation.run("abc").is(_.left) == Violations.of(Violation.NonIntegerString("abc")))
       }
     }
     suiteAll("maxLength() can test string length") {
       test("success") {
         val validation = Validations.maxLength(max = 4)
         val value      = "a".repeat(4)
-        assertTrue(validation.run(value) == Right(value))
+        assertTrue(validation.run(value).is(_.right) == value)
       }
       test("failure") {
         val validation = Validations.maxLength(max = 4)
         val value      = "a".repeat(5)
-        assertTrue(validation.run(value) == Left(Violations.of(Violation.TooLongString(value, maxLength = 4))))
+        assertTrue(validation.run(value).is(_.left) == Violations.of(Violation.TooLongString(value, maxLength = 4)))
       }
     }
     suiteAll("minLength() can test string length") {
       test("success") {
         val validation = Validations.minLength(min = 4)
         val value      = "a".repeat(4)
-        assertTrue(validation.run(value) == Right(value))
+        assertTrue(validation.run(value).is(_.right) == value)
       }
       test("failure") {
         val validation = Validations.minLength(min = 4)
         val value      = "a".repeat(3)
-        assertTrue(validation.run(value) == Left(Violations.of(Violation.TooShortString(value, minLength = 4))))
+        assertTrue(validation.run(value).is(_.left) == Violations.of(Violation.TooShortString(value, minLength = 4)))
       }
     }
     suiteAll("min() can test minimum value") {
       test("success") {
         val validation = Validations.min(n = 5)
-        assertTrue(validation.run(5) == Right(5))
+        assertTrue(validation.run(5).is(_.right) == 5)
       }
       test("failure") {
         val validation = Validations.min(n = 5)
-        assertTrue(validation.run(4) == Left(Violations.of(Violation.TooSmall(value = 4, min = 5))))
+        assertTrue(validation.run(4).is(_.left) == Violations.of(Violation.TooSmall(value = 4, min = 5)))
       }
     }
     suiteAll("max() can test maximum value") {
       test("success") {
         val validation = Validations.max(n = 10)
-        assertTrue(validation.run(10) == Right(10))
+        assertTrue(validation.run(10).is(_.right) == 10)
       }
       test("failure") {
         val validation = Validations.max(n = 10)
-        assertTrue(validation.run(11) == Left(Violations.of(Violation.TooLarge(value = 11, max = 10))))
+        assertTrue(validation.run(11).is(_.left) == Violations.of(Violation.TooLarge(value = 11, max = 10)))
       }
     }
     suiteAll("positive() can test positive value") {
       test("success") {
         val validation = Validations.positive
-        assertTrue(validation.run(1) == Right(1))
+        assertTrue(validation.run(1).is(_.right) == 1)
       }
       test("failure with zero") {
         val validation = Validations.positive
-        assertTrue(validation.run(0) == Left(Violations.of(Violation.NonPositive(value = 0))))
+        assertTrue(validation.run(0).is(_.left) == Violations.of(Violation.NonPositive(value = 0)))
       }
       test("failure with negative") {
         val validation = Validations.positive
-        assertTrue(validation.run(-1) == Left(Violations.of(Violation.NonPositive(value = -1))))
+        assertTrue(validation.run(-1).is(_.left) == Violations.of(Violation.NonPositive(value = -1)))
       }
     }
     suiteAll("matches() can test with regex") {
@@ -88,13 +88,13 @@ object ValidationsSpec extends ZIOSpecDefault {
         val pattern    = "^abc$".r
         val validation = Validations.matches(pattern)
         val value      = "abc"
-        assertTrue(validation.run(value) == Right(value))
+        assertTrue(validation.run(value).is(_.right) == value)
       }
       test("failure") {
         val pattern    = "^abc$".r
         val validation = Validations.matches(pattern)
         val value      = "abcd"
-        assertTrue(validation.run(value) == Left(Violations.of(Violation.Unmatched(value, pattern))))
+        assertTrue(validation.run(value).is(_.left) == Violations.of(Violation.Unmatched(value, pattern)))
       }
     }
   }

--- a/core/src/test/scala/yoshi/ValidationsSpec.scala
+++ b/core/src/test/scala/yoshi/ValidationsSpec.scala
@@ -8,7 +8,11 @@ object ValidationsSpec extends ZIOSpecDefault {
     suiteAll("required() can extract from Option") {
       test("success") {
         val validation = Validations.required[String]
-        assertTrue(validation.run(Some("hello")).is(_.right) == "hello")
+        for {
+          result <- validation.run(Some("hello"))
+        } yield {
+          assertTrue(result == "hello")
+        }
       }
       test("failure") {
         val validation = Validations.required[String]
@@ -18,7 +22,11 @@ object ValidationsSpec extends ZIOSpecDefault {
     suiteAll("parseInt() can parse string to int") {
       test("success") {
         val validation = Validations.parseInt
-        assertTrue(validation.run("42").is(_.right) == 42)
+        for {
+          result <- validation.run("42")
+        } yield {
+          assertTrue(result == 42)
+        }
       }
       test("failure") {
         val validation = Validations.parseInt
@@ -29,7 +37,12 @@ object ValidationsSpec extends ZIOSpecDefault {
       test("success") {
         val validation = Validations.maxLength(max = 4)
         val value      = "a".repeat(4)
-        assertTrue(validation.run(value).is(_.right) == value)
+
+        for {
+          result <- validation.run(value)
+        } yield {
+          assertTrue(result == value)
+        }
       }
       test("failure") {
         val validation = Validations.maxLength(max = 4)
@@ -41,7 +54,11 @@ object ValidationsSpec extends ZIOSpecDefault {
       test("success") {
         val validation = Validations.minLength(min = 4)
         val value      = "a".repeat(4)
-        assertTrue(validation.run(value).is(_.right) == value)
+        for {
+          result <- validation.run(value)
+        } yield {
+          assertTrue(result == value)
+        }
       }
       test("failure") {
         val validation = Validations.minLength(min = 4)
@@ -52,7 +69,11 @@ object ValidationsSpec extends ZIOSpecDefault {
     suiteAll("min() can test minimum value") {
       test("success") {
         val validation = Validations.min(n = 5)
-        assertTrue(validation.run(5).is(_.right) == 5)
+        for {
+          result <- validation.run(5)
+        } yield {
+          assertTrue(result == 5)
+        }
       }
       test("failure") {
         val validation = Validations.min(n = 5)
@@ -62,7 +83,11 @@ object ValidationsSpec extends ZIOSpecDefault {
     suiteAll("max() can test maximum value") {
       test("success") {
         val validation = Validations.max(n = 10)
-        assertTrue(validation.run(10).is(_.right) == 10)
+        for {
+          result <- validation.run(10)
+        } yield {
+          assertTrue(result == 10)
+        }
       }
       test("failure") {
         val validation = Validations.max(n = 10)
@@ -72,7 +97,11 @@ object ValidationsSpec extends ZIOSpecDefault {
     suiteAll("positive() can test positive value") {
       test("success") {
         val validation = Validations.positive
-        assertTrue(validation.run(1).is(_.right) == 1)
+        for {
+          result <- validation.run(1)
+        } yield {
+          assertTrue(result == 1)
+        }
       }
       test("failure with zero") {
         val validation = Validations.positive
@@ -88,7 +117,11 @@ object ValidationsSpec extends ZIOSpecDefault {
         val pattern    = "^abc$".r
         val validation = Validations.matches(pattern)
         val value      = "abc"
-        assertTrue(validation.run(value).is(_.right) == value)
+        for {
+          result <- validation.run(value)
+        } yield {
+          assertTrue(result == value)
+        }
       }
       test("failure") {
         val pattern    = "^abc$".r

--- a/docs/mdoc/index.md
+++ b/docs/mdoc/index.md
@@ -18,17 +18,11 @@ libraryDependencies += "io.github.hshn" %% "yoshi-core" % "@VERSION@"
 ## The idea
 
 Most validation libraries give you `Validated[E, A]` — a value that's either valid or not.
-Yoshi gives you `Validation[R, V, A, B]` — a **composable function** from `A` to `B` that accumulates violations on failure.
+Yoshi gives you `Validation[V, A, B]` — a **composable function** from `A` to `B` that accumulates violations on failure.
 
 ```scala mdoc:invisible
 import yoshi.*
 import yoshi.defaults.*
-import zio.*
-
-def runUnsafe[V, A, B](v: ZIO[Any, Violations[V], B]): Either[Violations[V], B] =
-  Unsafe.unsafe { implicit unsafe =>
-    Runtime.default.unsafe.run(v.either).getOrThrow()
-  }
 ```
 
 ```scala mdoc:silent
@@ -52,7 +46,7 @@ object Order:
 ```
 
 ```scala mdoc:silent
-given Validation[Any, Violation, FormInput.Item, Order.Item] =
+given Validation[Violation, FormInput.Item, Order.Item] =
   Validation.cursor[FormInput.Item] { c =>
     (
       c.validateAs[String](_.label)
@@ -61,7 +55,7 @@ given Validation[Any, Violation, FormInput.Item, Order.Item] =
     }
   }
 
-val validation: Validation[Any, Violation, FormInput, Order] =
+val validation: Validation[Violation, FormInput, Order] =
   Validation.cursor[FormInput] { c =>
     (
       c.validateAs[String](_.name),
@@ -78,7 +72,7 @@ The cursor derives field names from accessor lambdas at compile time — no manu
 When the path should differ from the field name, use `field()` with `.at()` to override:
 
 ```scala mdoc:silent
-val renamed: Validation[Any, Violation, FormInput, Order] =
+val renamed: Validation[Violation, FormInput, Order] =
   Validation.cursor[FormInput] { c =>
     (
       c.field(_.name).at("display_name").validateAs[String],
@@ -106,7 +100,7 @@ val invalid = FormInput(
 ```
 
 ```scala mdoc
-runUnsafe(validation.run(invalid)).left.map(_.toList)
+validation.run(invalid).left.map(_.toList)
 ```
 
 ## Automatic container derivation
@@ -118,21 +112,21 @@ import yoshi.*
 import yoshi.defaults.*
 
 // Given this exists:
-// given Validation[Any, Violation, String, Int]  (from yoshi.defaults)
+// given Validation[Violation, String, Int]  (from yoshi.defaults)
 
 // These are derived for free:
-summon[Validation[Any, Violation, Option[String], Option[Int]]]
-summon[Validation[Any, Violation, List[String], List[Int]]]
-summon[Validation[Any, Violation, Map[String, String], Map[String, Int]]]
+summon[Validation[Violation, Option[String], Option[Int]]]
+summon[Validation[Violation, List[String], List[Int]]]
+summon[Validation[Violation, Map[String, String], Map[String, Int]]]
 ```
 
 ## Composing validators
 
 ```scala mdoc:silent
-val nonEmpty: Validation[Any, String, String, String] =
+val nonEmpty: Validation[String, String, String] =
   Validation.ensure("required")((_: String).nonEmpty)
 
-val maxLen: Validation[Any, String, String, String] =
+val maxLen: Validation[String, String, String] =
   Validation.maxLength(100)((_, _) => "too long")
 
 // Parallel — accumulates all violations

--- a/docs/mdoc/index.md
+++ b/docs/mdoc/index.md
@@ -129,7 +129,7 @@ val nonEmpty: Validation[String, String, String] =
 val maxLen: Validation[String, String, String] =
   Validation.maxLength(100)((_, _) => "too long")
 
-// Parallel — accumulates all violations
+// Accumulating — collects all violations
 val both = nonEmpty |+| maxLen
 
 // Sequential — short-circuits on first failure

--- a/docs/superpowers/plans/2026-04-15-either-migration.md
+++ b/docs/superpowers/plans/2026-04-15-either-migration.md
@@ -1,0 +1,1495 @@
+# Either Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate `Validation[-R, +V, -A, +B]` to `Validation[+V, -A, +B]` with `Either[Violations[V], B]` result type, removing ZIO from core compile scope.
+
+**Architecture:** Replace all ZIO effect usage in core with pure `Either`. The `R` type parameter is removed from the entire public API. zio-prelude module is temporarily excluded from the build (out of scope for this migration).
+
+**Tech Stack:** Scala 3.3, sbt, ZIO Test (test scope only)
+
+**Note:** Tasks 2–7 modify interdependent source files. Core will not compile until all of Tasks 2–7 are complete. Run `sbt core/compile` after Task 7 to verify.
+
+---
+
+### Task 1: Update build.sbt
+
+**Files:**
+- Modify: `build.sbt`
+
+- [ ] **Step 1: Remove compile-scope ZIO and exclude zio-prelude**
+
+```scala
+lazy val root = (project in file(".") withId "yoshi")
+  .settings(
+    Compile / unmanagedSourceDirectories   := Nil,
+    Compile / unmanagedResourceDirectories := Nil,
+    Test / unmanagedSourceDirectories      := Nil,
+    Test / unmanagedResourceDirectories    := Nil,
+  )
+  .aggregate(
+    core,
+  )
+
+lazy val core = (project in file("core"))
+  .settings(
+    libraryDependencies ++= Seq(
+      "dev.zio" %% "zio-test"          % zio % Test,
+      "dev.zio" %% "zio-test-sbt"      % zio % Test,
+      "dev.zio" %% "zio-test-magnolia" % zio % Test,
+    ),
+  )
+```
+
+Changes:
+- Remove `zio-prelude` from `.aggregate(...)` (temporarily — it won't compile against the new core)
+- Remove `"dev.zio" %% "zio"` from core's `libraryDependencies` (only test deps remain)
+
+- [ ] **Step 2: Commit**
+
+```
+git add build.sbt
+git commit -m "build: remove compile-scope ZIO from core, exclude zio-prelude"
+```
+
+---
+
+### Task 2: Migrate Validation.scala
+
+**Files:**
+- Modify: `core/src/main/scala/yoshi/Validation.scala`
+
+- [ ] **Step 1: Replace the full file content**
+
+Remove `import zio.ZIO`. Change sealed class and all methods:
+
+```scala
+package yoshi
+
+import scala.util.matching.Regex
+
+sealed abstract class Validation[+V, -A, +B] { self =>
+
+  def run(a: A): Either[Violations[V], B]
+
+  def mapError[V1](f: V => V1): Validation[V1, A, B] =
+    Validation.instance[A] { a =>
+      self.run(a).left.map(_.map(f))
+    }
+
+  def contramap[A0](f: A0 => A): Validation[V, A0, B] =
+    Validation.instance[A0] { a0 =>
+      self.run(f(a0))
+    }
+
+  def map[C](f: B => C): Validation[V, A, C] =
+    Validation.instance[A] { a =>
+      for {
+        b <- run(a)
+      } yield {
+        f(b)
+      }
+    }
+
+  def |+|[V1 >: V, A1 <: A, B1 >: B](next: Validation[V1, A1, B1]): Validation[V1, A1, B1] =
+    Validation.instance { a =>
+      val lhs: Either[Violations[V1], B1] = run(a)
+      val rhs: Either[Violations[V1], B1] = next.run(a)
+      (lhs, rhs).validateN { case (b1, _) => b1 }
+    }
+
+  def >>[C, V1 >: V](next: Validation[V1, B, C]): Validation[V1, A, C] =
+    Validation.instance[A] { a =>
+      for {
+        b <- run(a)
+        c <- next.run(b)
+      } yield {
+        c
+      }
+    }
+
+  def orElse[V1 >: V, A1 <: A, B1 >: B](that: Validation[V1, A1, B1]): Validation[V1, A1, B1] =
+    Validation.instance[A1] { a =>
+      self.run(a) match
+        case r @ Right(_) => r
+        case Left(firstError) =>
+          that.run(a) match
+            case r @ Right(_) => r
+            case Left(_)      => Left(firstError)
+    }
+
+  def optional: Validation[V, Option[A], Option[B]] =
+    Validation.instance[Option[A]] {
+      case Some(a) => self.run(a).map(Some(_))
+      case None    => Right(None)
+    }
+}
+
+object Validation extends ValidationInstances {
+
+  final private class Impl[+V, -A, +B](f: A => Either[Violations[V], B]) extends Validation[V, A, B] {
+    def run(a: A): Either[Violations[V], B] = f(a)
+  }
+
+  def instance[A] = new InstancePartiallyApplied[A]
+
+  final class InstancePartiallyApplied[A] {
+    def apply[V, B](f: A => Either[Violations[V], B]): Validation[V, A, B] = new Impl(f)
+  }
+
+  def cursor[A] = new CursorPartiallyApplied[A]
+
+  final class CursorPartiallyApplied[A] {
+    def apply[V, B](f: ValidationCursor[A] => Either[Violations[V], B]): Validation[V, A, B] =
+      new Impl(a => f(new ValidationCursor(a)))
+  }
+
+  def succeed[A]: Validation[Nothing, A, A] =
+    instance[A](a => Right(a))
+
+  def fail[V](v: V): Validation[V, Any, Nothing] =
+    instance[Any](_ => Left(Violations.of(v)))
+
+  def ensure[V, A](f: => V)(test: A => Boolean): Validation[V, A, A] =
+    ensureOr[V, A](_ => f)(test)
+
+  def ensureOr[V, A](f: A => V)(test: A => Boolean): Validation[V, A, A] = instance[A] { a =>
+    if (test(a))
+      Right(a)
+    else
+      Left(Violations.of(f(a)))
+  }
+
+  def required[V, A](error: => V): Validation[V, Option[A], A] =
+    instance[Option[A]](_.toRight(Violations.of(error)))
+
+  def parseInt[V](error: String => V): Validation[V, String, Int] =
+    instance[String] { value =>
+      try Right(Integer.parseInt(value))
+      catch {
+        case _: NumberFormatException =>
+          Left(Violations.of(error(value)))
+      }
+    }
+
+  def maxLength[V](max: Int)(error: (String, Int) => V): Validation[V, String, String] =
+    ensureOr[V, String] { value =>
+      error(value, max)
+    } { value =>
+      value.length <= max
+    }
+
+  def minLength[V](min: Int)(error: (String, Int) => V): Validation[V, String, String] =
+    ensureOr[V, String] { value =>
+      error(value, min)
+    } { value =>
+      value.length >= min
+    }
+
+  def min[V](n: Int)(error: Int => V): Validation[V, Int, Int] =
+    ensureOr[V, Int](error)(_ >= n)
+
+  def max[V](n: Int)(error: Int => V): Validation[V, Int, Int] =
+    ensureOr[V, Int](error)(_ <= n)
+
+  def positive[V](error: Int => V): Validation[V, Int, Int] =
+    ensureOr[V, Int](error)(_ > 0)
+
+  def matches[V](pattern: Regex)(error: (String, Regex) => V): Validation[V, String, String] =
+    instance[String] { value =>
+      if (pattern.matches(value)) Right(value)
+      else Left(Violations.of(error(value, pattern)))
+    }
+
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```
+git add core/src/main/scala/yoshi/Validation.scala
+git commit -m "refactor: migrate Validation core type from ZIO to Either"
+```
+
+---
+
+### Task 3: Migrate ValidateAs.scala
+
+**Files:**
+- Modify: `core/src/main/scala/yoshi/syntax/ValidateAs.scala`
+
+- [ ] **Step 1: Replace the full file content**
+
+```scala
+package yoshi.syntax
+
+import yoshi.Validation
+import yoshi.Violations
+
+trait ValidateAs:
+  extension [A](a: A) def validateAs[B](using va: ValidatedAs[A, B]): Either[Violations[va.Err], B] = va.run(a)
+
+  extension [V, A](value: Either[Violations[V], A])
+    def at(path: Violations.Path): Either[Violations[V], A] = value.left.map(_.asChild(path))
+    def at(key: String): Either[Violations[V], A]           = at(Violations.Path.Key(key))
+    def at(index: Int): Either[Violations[V], A]            = at(Violations.Path.Index(index))
+
+sealed trait ValidatedAs[-A, +B]:
+  type Err
+  def run(a: A): Either[Violations[Err], B]
+
+object ValidatedAs:
+  final class Derived[V, A, B](v: Validation[V, A, B]) extends ValidatedAs[A, B]:
+    type Err = V
+    def run(a: A): Either[Violations[V], B] = v.run(a)
+
+  transparent inline given derive[V, A, B](using v: Validation[V, A, B]): ValidatedAs[A, B] =
+    new Derived(v)
+```
+
+- [ ] **Step 2: Commit**
+
+```
+git add core/src/main/scala/yoshi/syntax/ValidateAs.scala
+git commit -m "refactor: migrate ValidateAs/ValidatedAs from ZIO to Either"
+```
+
+---
+
+### Task 4: Migrate ValidateN.scala
+
+**Files:**
+- Modify: `core/src/main/scala/yoshi/syntax/ValidateN.scala`
+
+- [ ] **Step 1: Replace the full file content**
+
+```scala
+package yoshi.syntax
+
+import yoshi.Violations
+
+trait ValidateN:
+  extension [V, A](validation: Either[Violations[V], A])
+    def validateN[B](f: A => B): Either[Violations[V], B] =
+      validation.map(f)
+
+  extension [V, T <: Tuple, Out <: Tuple](validations: T)(using tv: ValidateTuple[V, T, Out])
+    def validateN[A](f: Out => A): Either[Violations[V], A] =
+      tv.validate(validations).map(f)
+
+sealed trait ValidateTuple[V, T <: Tuple, Out <: Tuple]:
+  def validate(t: T): Either[Violations[V], Out]
+
+object ValidateTuple:
+  given empty[V]: ValidateTuple[V, EmptyTuple, EmptyTuple] with
+    def validate(t: EmptyTuple): Either[Violations[V], EmptyTuple] =
+      Right(EmptyTuple)
+
+  given cons[V, H, T <: Tuple, TOut <: Tuple](using
+    tail: ValidateTuple[V, T, TOut],
+  ): ValidateTuple[V, Either[Violations[V], H] *: T, H *: TOut] with
+    def validate(t: Either[Violations[V], H] *: T): Either[Violations[V], H *: TOut] =
+      (t.head, tail.validate(t.tail)) match
+        case (Right(h), Right(t)) => Right(h *: t)
+        case (Left(e1), Left(e2)) => Left(e1 ++ e2)
+        case (Left(e), _)         => Left(e)
+        case (_, Left(e))         => Left(e)
+```
+
+- [ ] **Step 2: Commit**
+
+```
+git add core/src/main/scala/yoshi/syntax/ValidateN.scala
+git commit -m "refactor: migrate ValidateN from ZIO to Either"
+```
+
+---
+
+### Task 5: Migrate Cursor.scala
+
+**Files:**
+- Modify: `core/src/main/scala/yoshi/Cursor.scala`
+
+- [ ] **Step 1: Replace the full file content**
+
+```scala
+package yoshi
+
+import yoshi.Violations.Path
+import yoshi.Violations.Paths
+import yoshi.internal.fieldNames
+import yoshi.syntax.ValidatedAs
+
+final class ValidationCursor[A](private val underlying: A):
+
+  inline def field[B](inline f: A => B): CursorField[B] =
+    new CursorField(f(underlying), Paths(fieldNames(f).map(Path.Key(_))))
+
+  inline def validateAs[B] = new CursorValidateAs[A, B](underlying)
+
+final class CursorValidateAs[A, B](private val underlying: A):
+  inline def apply[F](inline f: A => F)(using va: ValidatedAs[F, B]): Either[Violations[va.Err], B] =
+    val paths = Paths(fieldNames(f).map(Path.Key(_)))
+    va.run(f(underlying)).left.map(_.asChild(paths))
+
+final class CursorField[B](val value: B, val path: Paths):
+
+  def validateAs[C](using va: ValidatedAs[B, C]): Either[Violations[va.Err], C] =
+    va.run(value).left.map(_.asChild(path))
+
+  def at(customPath: String): CursorField[B] =
+    new CursorField(value, Paths(List(Path.Key(customPath))))
+```
+
+- [ ] **Step 2: Commit**
+
+```
+git add core/src/main/scala/yoshi/Cursor.scala
+git commit -m "refactor: migrate Cursor from ZIO to Either"
+```
+
+---
+
+### Task 6: Migrate ValidationInstances.scala
+
+**Files:**
+- Modify: `core/src/main/scala/yoshi/ValidationInstances.scala`
+
+- [ ] **Step 1: Replace the full file content**
+
+```scala
+package yoshi
+
+trait ValidationInstances {
+
+  given optionCanBeValidatedAs[V, A, B](using validation: Validation[V, A, B]): Validation[V, Option[A], Option[B]] =
+    validation.optional
+
+  given seqCanBeValidatedAs[V, A, B](using validation: Validation[V, A, B]): Validation[V, Seq[A], Seq[B]] =
+    Validation.instance { values =>
+      val results = values.toList.zipWithIndex.map { case (a, index) =>
+        validation.run(a).left.map(_.asChild(index))
+      }
+      val (errors, successes) = results.partitionMap(identity)
+      if (errors.isEmpty) Right(successes)
+      else Left(errors.reduce(_ ++ _))
+    }
+
+  given listCanBeValidatedAs[V, A, B](using Validation[V, A, B]): Validation[V, List[A], List[B]] =
+    seqCanBeValidatedAs[V, A, B].contramap[List[A]](identity).map(_.toList)
+
+  given mapCanBeValidatedAs[V, A, B](using
+    validation: Validation[V, A, B],
+  ): Validation[V, Map[String, A], Map[String, B]] =
+    Validation.instance { values =>
+      val results = values.toList.map { case (key, a) =>
+        validation.run(a).left.map(_.asChild(key)).map(b => key -> b)
+      }
+      val (errors, successes) = results.partitionMap(identity)
+      if (errors.isEmpty) Right(successes.toMap)
+      else Left(errors.reduce(_ ++ _))
+    }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```
+git add core/src/main/scala/yoshi/ValidationInstances.scala
+git commit -m "refactor: migrate ValidationInstances from ZIO to Either"
+```
+
+---
+
+### Task 7: Migrate defaults
+
+**Files:**
+- Modify: `core/src/main/scala/yoshi/defaults/ValidationInstances.scala`
+- Modify: `core/src/main/scala/yoshi/defaults/Validations.scala`
+
+- [ ] **Step 1: Update defaults/ValidationInstances.scala**
+
+```scala
+package yoshi.defaults
+
+import yoshi.Validation
+
+implicit def optionCanBeDefined[A]: Validation[Violation, Option[A], A] =
+  Validations.required
+
+implicit val stringCanBeInt: Validation[Violation, String, Int] =
+  Validations.parseInt
+```
+
+- [ ] **Step 2: Update defaults/Validations.scala**
+
+```scala
+package yoshi.defaults
+
+import scala.util.matching.Regex
+import yoshi.*
+
+object Validations {
+
+  def required[A]: Validation[Violation, Option[A], A] =
+    Validation.required(Violation.Required)
+
+  def parseInt: Validation[Violation, String, Int] =
+    Validation.parseInt(Violation.NonIntegerString(_))
+
+  def maxLength(max: Int): Validation[Violation, String, String] =
+    Validation.maxLength(max)(Violation.TooLongString(_, _))
+
+  def minLength(min: Int): Validation[Violation, String, String] =
+    Validation.minLength(min)(Violation.TooShortString(_, _))
+
+  def matches(pattern: Regex): Validation[Violation, String, String] =
+    Validation.matches(pattern)(Violation.Unmatched(_, _))
+
+  def min(n: Int): Validation[Violation, Int, Int] =
+    Validation.min(n)(Violation.TooSmall(_, n))
+
+  def max(n: Int): Validation[Violation, Int, Int] =
+    Validation.max(n)(Violation.TooLarge(_, n))
+
+  def positive: Validation[Violation, Int, Int] =
+    Validation.positive(Violation.NonPositive(_))
+
+}
+```
+
+- [ ] **Step 3: Verify core compiles**
+
+Run: `sbt core/compile`
+Expected: Compilation succeeds
+
+- [ ] **Step 4: Commit**
+
+```
+git add core/src/main/scala/yoshi/defaults/ValidationInstances.scala core/src/main/scala/yoshi/defaults/Validations.scala
+git commit -m "refactor: update defaults type parameters for Either migration"
+```
+
+---
+
+### Task 8: Migrate tests — ValidationTransformsSpec
+
+**Files:**
+- Modify: `core/src/test/scala/yoshi/ValidationTransformsSpec.scala`
+
+- [ ] **Step 1: Replace the full file content**
+
+Key changes:
+- Remove `import zio.Promise` and `import zio.ZIO`
+- `Validation[Any, V, A, B]` → `Validation[V, A, B]`
+- `for result <- v.run(x) yield assertTrue(...)` → `assertTrue(v.run(x) == Right(...))`
+- `for result <- v.run(x).either yield assertTrue(...)` → `assertTrue(v.run(x) == Left(...))`
+- `Validation.instance[String](s => ZIO.succeed(...))` → `Validation.instance[String](s => Right(...))`
+- `ZIO.fail(...)` → `Left(...)`
+- Promise-based "does not run" test → use `var` to track side effects
+
+```scala
+package yoshi
+
+import yoshi.defaults.*
+import zio.test.*
+
+object ValidationTransformsSpec extends ZIOSpecDefault {
+  override def spec = suiteAll("Validation transforms") {
+    suiteAll("succeed") {
+      test("returns the input unchanged") {
+        assertTrue(Validation.succeed[String].run("hello") == Right("hello"))
+      }
+      test("is right identity for >>") {
+        val v = Validations.minLength(1)
+        assertTrue((v >> Validation.succeed).run("ab") == Right("ab"))
+      }
+      test("is left identity for >>") {
+        val v = Validations.minLength(1)
+        assertTrue((Validation.succeed >> v).run("ab") == Right("ab"))
+      }
+    }
+    suiteAll("fail") {
+      test("always fails with the given violation") {
+        val v = Validation.fail[Violation](Violation.Required)
+        assertTrue(v.run("anything") == Left(Violations.of[Violation](Violation.Required)))
+      }
+    }
+    suiteAll("contramap") {
+      test("adapt input type before validation") {
+        val nonEmpty: Validation[Violation, String, String]          = Validations.minLength(1)
+        val nameValidation: Validation[Violation, NameInput, String] =
+          nonEmpty.contramap(_.name.getOrElse(""))
+
+        assertTrue(nameValidation.run(NameInput(name = Some("Alice"))) == Right("Alice"))
+      }
+      test("propagate violations from adapted input") {
+        val minLength3: Validation[Violation, String, String]        = Validations.minLength(3)
+        val nameValidation: Validation[Violation, NameInput, String] =
+          minLength3.contramap(_.name.getOrElse(""))
+
+        assertTrue(nameValidation.run(NameInput(name = Some("ab"))) == Left(Violations(Vector(Violation.TooShortString("ab", 3)))))
+      }
+    }
+    suiteAll("mapError") {
+      test("transform error type on failure") {
+        val v = Validations.minLength(3).mapError(_.toString)
+
+        assertTrue(v.run("ab") == Left(Violations.of(Violation.TooShortString("ab", 3).toString)))
+      }
+      test("preserve success value") {
+        val v = Validations.minLength(1).mapError(_.toString)
+
+        assertTrue(v.run("hello") == Right("hello"))
+      }
+      test("transform nested violations preserving structure") {
+        val v = Validation
+          .instance[String] { s =>
+            Left(
+              Violations[Violation](
+                values = Vector(Violation.Required),
+                children = Map(
+                  Violations.Path("child") -> Violations.of(Violation.TooShortString(s, 3)),
+                ),
+              ),
+            )
+          }
+          .mapError(_.toString)
+
+        assertTrue(
+          v.run("ab") == Left(
+            Violations[String](
+              values = Vector(Violation.Required.toString),
+              children = Map(
+                Violations.Path("child") -> Violations.of(Violation.TooShortString("ab", 3).toString),
+              ),
+            ),
+          ),
+        )
+      }
+      test("compose with >>") {
+        val first: Validation[Violation, String, String]  = Validations.minLength(1)
+        val second: Validation[Violation, String, String] = Validations.maxLength(3)
+        val v                                             = (first >> second).mapError(_.toString)
+
+        assertTrue(v.run("hello") == Left(Violations.of(Violation.TooLongString("hello", 3).toString)))
+      }
+      test("compose with |+|") {
+        val v = (Validations.minLength(3) |+| Validations.maxLength(1)).mapError(_.toString)
+
+        assertTrue(
+          v.run("ab") == Left(
+            Violations(
+              Vector(
+                Violation.TooShortString("ab", 3).toString,
+                Violation.TooLongString("ab", 1).toString,
+              ),
+            ),
+          ),
+        )
+      }
+    }
+    suiteAll("optional") {
+      test("pass through None as success") {
+        val v = Validations.minLength(3).optional
+        assertTrue(v.run(None) == Right(None))
+      }
+      test("validate Some value and wrap result in Some") {
+        val v = Validations.minLength(3).optional
+        assertTrue(v.run(Some("hello")) == Right(Some("hello")))
+      }
+      test("fail when Some value is invalid") {
+        val v = Validations.minLength(3).optional
+        assertTrue(v.run(Some("ab")) == Left(Violations.of(Violation.TooShortString("ab", 3))))
+      }
+      test("compose with map") {
+        val v = Validations.minLength(1).optional.map(_.map(_.length))
+        assertTrue(v.run(Some("hello")) == Right(Some(5)))
+      }
+      test("compose with sequential >>") {
+        val v = (Validations.minLength(1) >> Validations.maxLength(5)).optional
+        assertTrue(v.run(Some("abc")) == Right(Some("abc")))
+      }
+      test("fail in sequential >> composition") {
+        val v = (Validations.minLength(1) >> Validations.maxLength(3)).optional
+        assertTrue(v.run(Some("hello")) == Left(Violations.of(Violation.TooLongString("hello", 3))))
+      }
+      test("does not run underlying validation for None") {
+        var called = false
+        val raw    = Validation.instance[String] { _ => called = true; Right("ok") }
+        raw.optional.run(None)
+        assertTrue(!called)
+      }
+    }
+  }
+
+  private case class NameInput(name: Option[String])
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```
+git add core/src/test/scala/yoshi/ValidationTransformsSpec.scala
+git commit -m "test: migrate ValidationTransformsSpec to Either"
+```
+
+---
+
+### Task 9: Migrate tests — ValidationCombinatorsSpec
+
+**Files:**
+- Modify: `core/src/test/scala/yoshi/ValidationCombinatorsSpec.scala`
+
+- [ ] **Step 1: Replace the full file content**
+
+Key changes:
+- Remove `import zio.Promise` and `import zio.ZIO`
+- `Validation.instance[String](s => ZIO.succeed(...))` → `Validation.instance[String](s => Right(...))`
+- Promise-based "does not run" tests → use `var`
+
+```scala
+package yoshi
+
+import yoshi.Validation.*
+import yoshi.defaults.*
+import zio.test.*
+
+object ValidationCombinatorsSpec extends ZIOSpecDefault {
+  override def spec = suiteAll("Validation combinators") {
+    suiteAll("|+|") {
+      test("result violations when invalid") {
+        val validation         = Validations.minLength(3) |+| Validations.maxLength(1)
+        val expectedViolations = Violations(
+          Vector(
+            Violation.TooShortString("ab", 3),
+            Violation.TooLongString("ab", 1),
+          ),
+        )
+
+        assertTrue(validation.run("ab") == Left(expectedViolations))
+      }
+      test("result value when valid") {
+        val validation = (Validations.minLength(1) |+| Validations.maxLength(2))
+          .map(_.length)
+
+        assertTrue(validation.run("ab") == Right(2))
+      }
+      test("return left value when both succeed") {
+        val left: Validation[Violation, String, String] =
+          Validation.instance[String](s => Right(s.toUpperCase))
+        val right: Validation[Violation, String, String] =
+          Validation.instance[String](s => Right(s.toLowerCase))
+
+        assertTrue((left |+| right).run("Ab") == Right("AB"))
+      }
+    }
+    suiteAll(">>") {
+      test("chain two validations sequentially") {
+        val first: Validation[Violation, String, String] = Validations.minLength(1)
+        val second: Validation[Violation, String, Int] = Validation.instance[String] { s =>
+          Right(s.length)
+        }
+
+        assertTrue((first >> second).run("hello") == Right(5))
+      }
+      test("fail on first validation") {
+        val first: Validation[Violation, String, String] = Validations.minLength(10)
+        val second: Validation[Violation, String, Int] = Validation.instance[String] { s =>
+          Right(s.length)
+        }
+
+        assertTrue((first >> second).run("hi") == Left(Violations.of(Violation.TooShortString("hi", 10))))
+      }
+      test("fail on second validation") {
+        val first: Validation[Violation, String, String]  = Validations.minLength(1)
+        val second: Validation[Violation, String, String] = Validations.maxLength(2)
+
+        assertTrue((first >> second).run("hello") == Left(Violations.of(Violation.TooLongString("hello", 2))))
+      }
+      test("does not run second validation when first fails") {
+        var secondCalled = false
+        val first        = Validations.minLength(10)
+        val second       = Validation.instance[String] { _ => secondCalled = true; Right(0) }
+        (first >> second).run("hi")
+        assertTrue(!secondCalled)
+      }
+    }
+    suiteAll("orElse") {
+      test("return first result when first succeeds") {
+        val first: Validation[Violation, String, String]  = Validations.minLength(1)
+        val second: Validation[Violation, String, String] = Validations.minLength(5)
+
+        assertTrue(first.orElse(second).run("ab") == Right("ab"))
+      }
+      test("fall back to second when first fails") {
+        val first: Validation[Violation, String, String]  = Validations.minLength(10)
+        val second: Validation[Violation, String, String] = Validations.minLength(1)
+
+        assertTrue(first.orElse(second).run("hello") == Right("hello"))
+      }
+      test("return first violation when both fail") {
+        val first: Validation[Violation, String, String]  = Validations.minLength(10)
+        val second: Validation[Violation, String, String] = Validations.maxLength(1)
+
+        assertTrue(first.orElse(second).run("hello") == Left(Violations.of(Violation.TooShortString("hello", 10))))
+      }
+      test("does not run second when first succeeds") {
+        var secondCalled = false
+        val first        = Validation.instance[String](s => Right(s))
+        val second       = Validation.instance[String] { _ => secondCalled = true; Right("fallback") }
+        first.orElse(second).run("ok")
+        assertTrue(!secondCalled)
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```
+git add core/src/test/scala/yoshi/ValidationCombinatorsSpec.scala
+git commit -m "test: migrate ValidationCombinatorsSpec to Either"
+```
+
+---
+
+### Task 10: Migrate tests — ValidationProductSpec
+
+**Files:**
+- Modify: `core/src/test/scala/yoshi/ValidationProductSpec.scala`
+
+- [ ] **Step 1: Replace the full file content**
+
+Key changes:
+- Remove `import zio.Promise`
+- Remove the "validateN runs validations in parallel" test (no parallelism with Either)
+- `Validation[Any, V, A, B]` → `Validation[V, A, B]`
+
+```scala
+package yoshi
+
+import yoshi.Validation.*
+import yoshi.Violations.Path
+import yoshi.defaults.*
+import zio.test.*
+
+object ValidationProductSpec extends ZIOSpecDefault {
+  given childValidation: Validation[Violation, Dirty.Child, Clean.Child] =
+    Validation.instance[Dirty.Child] { dirty =>
+      (
+        dirty.name.validateAs[String].at("name")
+      ).validateN { name =>
+        Clean.Child(name = name)
+      }
+    }
+
+  val validation: Validation[Violation, Dirty, Clean] =
+    Validation.instance[Dirty] { dirty =>
+      (
+        dirty.a1.validateAs[String].at("a1"),
+        dirty.a2.validateAs[Int].at("a2"),
+        dirty.a3.validateAs[List[Clean.Child]].at("a3"),
+        dirty.a4.validateAs[Map[String, Clean.Child]].at("a4"),
+      ).validateN { case (a1, a2, a3, a4) =>
+        Clean(
+          a1 = a1,
+          a2 = a2,
+          a3 = a3,
+          a4 = a4,
+        )
+      }
+    }
+
+  override def spec = suiteAll("Validation product") {
+    suiteAll("forProduct()") {
+      test("result violations when invalid") {
+        val invalid = Dirty(
+          a1 = None,
+          a2 = "yay",
+          a3 = List(
+            Dirty.Child(name = Some("0")),
+            Dirty.Child(name = None),
+            Dirty.Child(name = Some("2")),
+            Dirty.Child(name = Some("3")),
+            Dirty.Child(name = None),
+            Dirty.Child(name = Some("5")),
+          ),
+          a4 = Map(
+            "a" -> Dirty.Child(name = None),
+            "b" -> Dirty.Child(name = Some("1")),
+            "c" -> Dirty.Child(name = None),
+            "d" -> Dirty.Child(name = None),
+            "e" -> Dirty.Child(name = Some("4")),
+            "f" -> Dirty.Child(name = None),
+          ),
+        )
+
+        val expectedViolations = Violations[Violation](
+          children = Map(
+            Path("a1") -> Violations(Vector(Violation.Required)),
+            Path("a2") -> Violations(Vector(Violation.NonIntegerString("yay"))),
+            Path("a3") -> Violations(
+              children = Map(
+                Path(1) -> Violations(Vector(Violation.Required)).asChild("name"),
+                Path(4) -> Violations(Vector(Violation.Required)).asChild("name"),
+              ),
+            ),
+            Path("a4") -> Violations(
+              children = Map(
+                Path("a") -> Violations(Vector(Violation.Required)).asChild("name"),
+                Path("c") -> Violations(Vector(Violation.Required)).asChild("name"),
+                Path("d") -> Violations(Vector(Violation.Required)).asChild("name"),
+                Path("f") -> Violations(Vector(Violation.Required)).asChild("name"),
+              ),
+            ),
+          ),
+        )
+
+        assertTrue(validation.run(invalid) == Left(expectedViolations))
+      }
+      test("result transformed object when valid") {
+        val valid = Dirty(
+          a1 = Some("hi"),
+          a2 = "123",
+          a3 = List(
+            Dirty.Child(name = Some("0")),
+            Dirty.Child(name = Some("2")),
+            Dirty.Child(name = Some("3")),
+            Dirty.Child(name = Some("5")),
+          ),
+          a4 = Map(
+            "b" -> Dirty.Child(name = Some("1")),
+            "e" -> Dirty.Child(name = Some("4")),
+          ),
+        )
+
+        val expectedObject = Clean(
+          a1 = "hi",
+          a2 = 123,
+          a3 = List(
+            Clean.Child(name = "0"),
+            Clean.Child(name = "2"),
+            Clean.Child(name = "3"),
+            Clean.Child(name = "5"),
+          ),
+          a4 = Map(
+            "b" -> Clean.Child(name = "1"),
+            "e" -> Clean.Child(name = "4"),
+          ),
+        )
+
+        assertTrue(validation.run(valid) == Right(expectedObject))
+      }
+    }
+  }
+
+  case class Dirty(
+    a1: Option[String],
+    a2: String,
+    a3: List[Dirty.Child],
+    a4: Map[String, Dirty.Child],
+  )
+
+  object Dirty {
+    case class Child(name: Option[String])
+  }
+
+  case class Clean(
+    a1: String,
+    a2: Int,
+    a3: List[Clean.Child],
+    a4: Map[String, Clean.Child],
+  )
+
+  object Clean {
+    case class Child(name: String)
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```
+git add core/src/test/scala/yoshi/ValidationProductSpec.scala
+git commit -m "test: migrate ValidationProductSpec to Either"
+```
+
+---
+
+### Task 11: Migrate tests — ValidationsSpec, CursorSpec, ValidationTypeclassSpec
+
+**Files:**
+- Modify: `core/src/test/scala/yoshi/ValidationsSpec.scala`
+- Modify: `core/src/test/scala/yoshi/CursorSpec.scala`
+- Modify: `core/src/test/scala/yoshi/ValidationTypeclassSpec.scala`
+
+These tests have no ZIO-specific logic (no `Promise`, no `ZIO.succeed`/`ZIO.fail`). Changes are mechanical:
+- `for result <- v.run(x) yield assertTrue(...)` → `assertTrue(v.run(x) == Right(...))`
+- `for result <- v.run(x).either yield assertTrue(result.is(_.left) == ...)` → `assertTrue(v.run(x) == Left(...))`
+- `Validation[Any, V, A, B]` → `Validation[V, A, B]`
+- Multi-validation `for` blocks → sequential `val` bindings
+
+- [ ] **Step 1: Update ValidationsSpec.scala**
+
+```scala
+package yoshi
+
+import yoshi.defaults.*
+import zio.test.*
+
+object ValidationsSpec extends ZIOSpecDefault {
+  override def spec = suiteAll("Validations") {
+    suiteAll("required() can extract from Option") {
+      test("success") {
+        assertTrue(Validations.required[String].run(Some("hello")) == Right("hello"))
+      }
+      test("failure") {
+        assertTrue(Validations.required[String].run(None) == Left(Violations.of(Violation.Required)))
+      }
+    }
+    suiteAll("parseInt() can parse string to int") {
+      test("success") {
+        assertTrue(Validations.parseInt.run("42") == Right(42))
+      }
+      test("failure") {
+        assertTrue(Validations.parseInt.run("abc") == Left(Violations.of(Violation.NonIntegerString("abc"))))
+      }
+    }
+    suiteAll("maxLength() can test string length") {
+      test("success") {
+        val value = "a".repeat(4)
+        assertTrue(Validations.maxLength(max = 4).run(value) == Right(value))
+      }
+      test("failure") {
+        val value = "a".repeat(5)
+        assertTrue(Validations.maxLength(max = 4).run(value) == Left(Violations.of(Violation.TooLongString(value, maxLength = 4))))
+      }
+    }
+    suiteAll("minLength() can test string length") {
+      test("success") {
+        val value = "a".repeat(4)
+        assertTrue(Validations.minLength(min = 4).run(value) == Right(value))
+      }
+      test("failure") {
+        val value = "a".repeat(3)
+        assertTrue(Validations.minLength(min = 4).run(value) == Left(Violations.of(Violation.TooShortString(value, minLength = 4))))
+      }
+    }
+    suiteAll("min() can test minimum value") {
+      test("success") {
+        assertTrue(Validations.min(n = 5).run(5) == Right(5))
+      }
+      test("failure") {
+        assertTrue(Validations.min(n = 5).run(4) == Left(Violations.of(Violation.TooSmall(value = 4, min = 5))))
+      }
+    }
+    suiteAll("max() can test maximum value") {
+      test("success") {
+        assertTrue(Validations.max(n = 10).run(10) == Right(10))
+      }
+      test("failure") {
+        assertTrue(Validations.max(n = 10).run(11) == Left(Violations.of(Violation.TooLarge(value = 11, max = 10))))
+      }
+    }
+    suiteAll("positive() can test positive value") {
+      test("success") {
+        assertTrue(Validations.positive.run(1) == Right(1))
+      }
+      test("failure with zero") {
+        assertTrue(Validations.positive.run(0) == Left(Violations.of(Violation.NonPositive(value = 0))))
+      }
+      test("failure with negative") {
+        assertTrue(Validations.positive.run(-1) == Left(Violations.of(Violation.NonPositive(value = -1))))
+      }
+    }
+    suiteAll("matches() can test with regex") {
+      test("success") {
+        val pattern = "^abc$".r
+        val value   = "abc"
+        assertTrue(Validations.matches(pattern).run(value) == Right(value))
+      }
+      test("failure") {
+        val pattern = "^abc$".r
+        val value   = "abcd"
+        assertTrue(Validations.matches(pattern).run(value) == Left(Violations.of(Violation.Unmatched(value, pattern))))
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Update CursorSpec.scala**
+
+```scala
+package yoshi
+
+import yoshi.defaults.*
+import zio.test.*
+
+object CursorSpec extends ZIOSpecDefault {
+
+  case class Input(
+    name: Option[String],
+    age: String,
+    items: List[Input.Item],
+    address: Input.Address,
+  )
+
+  object Input:
+    case class Item(label: Option[String])
+    case class Address(zip: Option[String])
+
+  case class Output(
+    name: String,
+    age: Int,
+    items: List[Output.Item],
+  )
+
+  object Output:
+    case class Item(label: String)
+
+  given Validation[Violation, Input.Item, Output.Item] =
+    Validation.cursor[Input.Item] { c =>
+      (
+        c.field(_.label).validateAs[String]
+      ).validateN { label =>
+        Output.Item(label)
+      }
+    }
+
+  val validation: Validation[Violation, Input, Output] =
+    Validation.cursor[Input] { c =>
+      (
+        c.field(_.name).validateAs[String],
+        c.field(_.age).validateAs[Int],
+        c.field(_.items).validateAs[List[Output.Item]],
+      ).validateN { case (name, age, items) =>
+        Output(name, age, items)
+      }
+    }
+
+  override def spec = suiteAll("Validation.cursor") {
+    suiteAll("field") {
+      test("transforms valid input") {
+        val input = Input(
+          name = Some("Alice"),
+          age = "30",
+          items = List(Input.Item(Some("item1")), Input.Item(Some("item2"))),
+          address = Input.Address(Some("12345")),
+        )
+        val expected = Output(
+          name = "Alice",
+          age = 30,
+          items = List(Output.Item("item1"), Output.Item("item2")),
+        )
+
+        assertTrue(validation.run(input) == Right(expected))
+      }
+
+      test("accumulates violations with correct paths") {
+        val input = Input(
+          name = None,
+          age = "abc",
+          items = List(Input.Item(Some("ok")), Input.Item(None)),
+          address = Input.Address(None),
+        )
+
+        val expected = Violations[Violation](
+          children = Map(
+            Violations.Path("name")  -> Violations(Vector(Violation.Required)),
+            Violations.Path("age")   -> Violations(Vector(Violation.NonIntegerString("abc"))),
+            Violations.Path("items") -> Violations(
+              children = Map(
+                Violations.Path(1) -> Violations(Vector(Violation.Required)).asChild("label"),
+              ),
+            ),
+          ),
+        )
+
+        assertTrue(validation.run(input) == Left(expected))
+      }
+
+      test("produces same result as manual .at() calls") {
+        val manualValidation: Validation[Violation, Input, Output] =
+          Validation.instance[Input] { dirty =>
+            (
+              dirty.name.validateAs[String].at("name"),
+              dirty.age.validateAs[Int].at("age"),
+              dirty.items.validateAs[List[Output.Item]].at("items"),
+            ).validateN { case (name, age, items) =>
+              Output(name, age, items)
+            }
+          }
+
+        val invalid = Input(name = None, age = "xyz", items = List(Input.Item(None)), address = Input.Address(None))
+
+        assertTrue(validation.run(invalid) == manualValidation.run(invalid))
+      }
+    }
+
+    suiteAll("nested field access") {
+      test("derives full path from nested accessor") {
+        val v: Validation[Violation, Input, String] =
+          Validation.cursor[Input] { c =>
+            c.field(_.address.zip).validateAs[String]
+          }
+
+        val input = Input(name = None, age = "", items = Nil, address = Input.Address(None))
+
+        val expected = Violations[Violation](
+          children = Map(
+            Violations.Path("address") -> Violations(
+              children = Map(
+                Violations.Path("zip") -> Violations(Vector(Violation.Required)),
+              ),
+            ),
+          ),
+        )
+        assertTrue(v.run(input) == Left(expected))
+      }
+    }
+
+    suiteAll("field with .at() override") {
+      test("uses overridden path instead of derived name") {
+        val v: Validation[Violation, Input, String] =
+          Validation.cursor[Input] { c =>
+            c.field(_.name).at("display_name").validateAs[String]
+          }
+
+        val expected = Violations[Violation](
+          children = Map(
+            Violations.Path("display_name") -> Violations(Vector(Violation.Required)),
+          ),
+        )
+        assertTrue(v.run(Input(name = None, age = "", items = Nil, address = Input.Address(None))) == Left(expected))
+      }
+    }
+
+    suiteAll("validateAs shorthand") {
+      test("produces same result as field().validateAs") {
+        val withField: Validation[Violation, Input, String] =
+          Validation.cursor[Input] { c =>
+            c.field(_.name).validateAs[String]
+          }
+
+        val withShorthand: Validation[Violation, Input, String] =
+          Validation.cursor[Input] { c =>
+            c.validateAs[String](_.name)
+          }
+
+        val invalid = Input(name = None, age = "", items = Nil, address = Input.Address(None))
+
+        assertTrue(withField.run(invalid) == withShorthand.run(invalid))
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Update ValidationTypeclassSpec.scala**
+
+```scala
+package yoshi
+
+import yoshi.Violations.Path
+import yoshi.defaults.*
+import zio.test.*
+
+object ValidationTypeclassSpec extends ZIOSpecDefault {
+  override def spec = suiteAll("Validation typeclass instances") {
+    suiteAll("optionCanBeValidatedAs") {
+      test("derive Option validation from given") {
+        given Validation[Violation, String, String] = Validations.minLength(1)
+        val v                                       = summon[Validation[Violation, Option[String], Option[String]]]
+
+        assertTrue(v.run(Some("hello")) == Right(Some("hello")))
+      }
+      test("pass through None") {
+        given Validation[Violation, String, String] = Validations.minLength(1)
+        val v                                       = summon[Validation[Violation, Option[String], Option[String]]]
+
+        assertTrue(v.run(None) == Right(None))
+      }
+      test("fail when Some value is invalid") {
+        given Validation[Violation, String, String] = Validations.minLength(5)
+        val v                                       = summon[Validation[Violation, Option[String], Option[String]]]
+
+        assertTrue(v.run(Some("ab")) == Left(Violations.of(Violation.TooShortString("ab", 5))))
+      }
+    }
+    suiteAll("seqCanBeValidatedAs") {
+      test("validate all elements in Seq") {
+        given Validation[Violation, String, String] = Validations.minLength(1)
+        val v                                       = summon[Validation[Violation, Seq[String], Seq[String]]]
+
+        assertTrue(v.run(Seq("a", "bb", "ccc")) == Right(Seq("a", "bb", "ccc")))
+      }
+      test("succeed with empty Seq") {
+        given Validation[Violation, String, String] = Validations.minLength(1)
+        val v                                       = summon[Validation[Violation, Seq[String], Seq[String]]]
+
+        assertTrue(v.run(Seq.empty) == Right(Seq.empty))
+      }
+      test("accumulate violations with indices") {
+        given Validation[Violation, String, String] = Validations.minLength(3)
+        val v                                       = summon[Validation[Violation, Seq[String], Seq[String]]]
+
+        val expectedViolations = Violations[Violation](
+          children = Map(
+            Path(0) -> Violations(Vector(Violation.TooShortString("ab", 3))),
+            Path(2) -> Violations(Vector(Violation.TooShortString("x", 3))),
+          ),
+        )
+
+        assertTrue(v.run(Seq("ab", "hello", "x")) == Left(expectedViolations))
+      }
+    }
+    suiteAll("listCanBeValidatedAs") {
+      test("validate all elements in List") {
+        given Validation[Violation, String, String] = Validations.minLength(1)
+        val v                                       = summon[Validation[Violation, List[String], List[String]]]
+
+        assertTrue(v.run(List("a", "bb", "ccc")) == Right(List("a", "bb", "ccc")))
+      }
+      test("accumulate violations with indices") {
+        given Validation[Violation, String, String] = Validations.minLength(3)
+        val v                                       = summon[Validation[Violation, List[String], List[String]]]
+
+        val expectedViolations = Violations[Violation](
+          children = Map(
+            Path(0) -> Violations(Vector(Violation.TooShortString("ab", 3))),
+            Path(2) -> Violations(Vector(Violation.TooShortString("x", 3))),
+          ),
+        )
+
+        assertTrue(v.run(List("ab", "hello", "x")) == Left(expectedViolations))
+      }
+    }
+    suiteAll("mapCanBeValidatedAs") {
+      test("validate all values in Map") {
+        given Validation[Violation, String, String] = Validations.minLength(1)
+        val v                                       = summon[Validation[Violation, Map[String, String], Map[String, String]]]
+        val input                                   = Map(
+          "a" -> "x",
+          "b" -> "yy",
+        )
+
+        assertTrue(v.run(input) == Right(input))
+      }
+      test("accumulate violations with keys") {
+        given Validation[Violation, String, String] = Validations.minLength(3)
+        val v                                       = summon[Validation[Violation, Map[String, String], Map[String, String]]]
+
+        val expectedViolations = Violations[Violation](
+          children = Map(
+            Path("a") -> Violations(Vector(Violation.TooShortString("ab", 3))),
+            Path("c") -> Violations(Vector(Violation.TooShortString("x", 3))),
+          ),
+        )
+
+        assertTrue(v.run(Map("a" -> "ab", "b" -> "hello", "c" -> "x")) == Left(expectedViolations))
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```
+git add core/src/test/scala/yoshi/ValidationsSpec.scala core/src/test/scala/yoshi/CursorSpec.scala core/src/test/scala/yoshi/ValidationTypeclassSpec.scala
+git commit -m "test: migrate ValidationsSpec, CursorSpec, ValidationTypeclassSpec to Either"
+```
+
+---
+
+### Task 12: Run tests and verify
+
+- [ ] **Step 1: Run all core tests**
+
+Run: `sbt core/test`
+Expected: All tests pass
+
+- [ ] **Step 2: Fix any compilation or test failures**
+
+If failures occur, diagnose and fix. Common issues:
+- Missing import removals
+- Type parameter count mismatches
+- `.either` calls that were not removed
+
+- [ ] **Step 3: Commit any fixes**
+
+```
+git add -p
+git commit -m "fix: resolve test failures from Either migration"
+```
+
+---
+
+### Task 13: Update documentation
+
+**Files:**
+- Modify: `docs/mdoc/index.md`
+
+- [ ] **Step 1: Replace the full file content**
+
+```markdown
+---
+id: index
+title: Getting Started
+slug: /
+sidebar_position: 1
+---
+
+# yoshi
+
+A validation library that transforms untyped input into domain types — not just checking values, but parsing them into a stronger representation.
+
+## Setup
+
+```scala
+libraryDependencies += "io.github.hshn" %% "yoshi-core" % "@VERSION@"
+```
+
+## The idea
+
+Most validation libraries give you `Validated[E, A]` — a value that's either valid or not.
+Yoshi gives you `Validation[V, A, B]` — a **composable function** from `A` to `B` that accumulates violations on failure.
+
+```scala mdoc:silent
+import yoshi.*
+import yoshi.defaults.*
+
+// Untyped input — what you receive
+case class FormInput(
+  name: Option[String],
+  age: String,
+  items: List[FormInput.Item],
+)
+object FormInput:
+  case class Item(label: Option[String])
+
+// Domain type — what you want
+case class Order(
+  name: String,
+  age: Int,
+  items: List[Order.Item],
+)
+object Order:
+  case class Item(label: String)
+```
+
+```scala mdoc:silent
+given Validation[Violation, FormInput.Item, Order.Item] =
+  Validation.cursor[FormInput.Item] { c =>
+    (
+      c.validateAs[String](_.label)
+    ).validateN { label =>
+      Order.Item(label)
+    }
+  }
+
+val validation: Validation[Violation, FormInput, Order] =
+  Validation.cursor[FormInput] { c =>
+    (
+      c.validateAs[String](_.name),
+      c.validateAs[Int](_.age),
+      c.validateAs[List[Order.Item]](_.items),
+    ).validateN { case (name, age, items) =>
+      Order(name, age, items)
+    }
+  }
+```
+
+The cursor derives field names from accessor lambdas at compile time — no manual `.at("field")` strings needed.
+
+When the path should differ from the field name, use `field()` with `.at()` to override:
+
+```scala mdoc:silent
+val renamed: Validation[Violation, FormInput, Order] =
+  Validation.cursor[FormInput] { c =>
+    (
+      c.field(_.name).at("display_name").validateAs[String],
+      c.validateAs[Int](_.age),
+      c.validateAs[List[Order.Item]](_.items),
+    ).validateN { case (name, age, items) =>
+      Order(name, age, items)
+    }
+  }
+```
+
+## Path-aware error accumulation
+
+Violations carry the full path to where they occurred:
+
+```scala mdoc:silent
+val invalid = FormInput(
+  name = None,
+  age = "abc",
+  items = List(
+    FormInput.Item(Some("pen")),
+    FormInput.Item(None),
+  ),
+)
+```
+
+```scala mdoc
+validation.run(invalid).left.map(_.toList)
+```
+
+## Automatic container derivation
+
+Define a validator for `A → B`, and validators for `Option[A]`, `List[A]`, `Map[String, A]` are derived automatically:
+
+```scala mdoc:compile-only
+import yoshi.*
+import yoshi.defaults.*
+
+// Given this exists:
+// given Validation[Violation, String, Int]  (from yoshi.defaults)
+
+// These are derived for free:
+summon[Validation[Violation, Option[String], Option[Int]]]
+summon[Validation[Violation, List[String], List[Int]]]
+summon[Validation[Violation, Map[String, String], Map[String, Int]]]
+```
+
+## Composing validators
+
+```scala mdoc:silent
+val nonEmpty: Validation[String, String, String] =
+  Validation.ensure("required")((_: String).nonEmpty)
+
+val maxLen: Validation[String, String, String] =
+  Validation.maxLength(100)((_, _) => "too long")
+
+// Parallel — accumulates all violations
+val both = nonEmpty |+| maxLen
+
+// Sequential — short-circuits on first failure
+val chain = nonEmpty >> maxLen
+```
+```
+
+- [ ] **Step 2: Commit**
+
+```
+git add docs/mdoc/index.md
+git commit -m "docs: update examples for Either-based validation API"
+```
+
+---
+
+### Task 14: Final verification
+
+- [ ] **Step 1: Run all core tests again**
+
+Run: `sbt core/test`
+Expected: All tests pass
+
+- [ ] **Step 2: Verify no ZIO imports remain in core main sources**
+
+Run: `grep -r "import zio" core/src/main/`
+Expected: No output (no ZIO imports in core main sources)

--- a/docs/superpowers/specs/2026-04-15-either-migration-design.md
+++ b/docs/superpowers/specs/2026-04-15-either-migration-design.md
@@ -1,0 +1,140 @@
+# Validation結果のEither化
+
+## 概要
+
+`Validation[-R, +V, -A, +B]` から ZIO 依存を除去し、`Validation[+V, -A, +B]` に変更する。
+`run` の戻り値を `ZIO[R, Violations[V], B]` から `Either[Violations[V], B]` に変える。
+
+## 動機
+
+- `R`（ZIO環境）パラメータは全ての組み込みバリデータで `Any` であり、実質未使用
+- DI が必要なバリデーション（DB重複チェック、時刻依存）は Aggregate やアプリケーション層の責務
+- バリデーションライブラリの本質は純粋な入力変換であり、`Either` が責務を正確に表現する
+- ZIO を知らないユーザーでも利用可能になる
+
+## スコープ
+
+- **対象**: core モジュールのみ
+- **対象外**: zio-prelude モジュール（後続で対応。core の型変更によりコンパイル不可になる）
+
+## 変更内容
+
+### Validation 型
+
+```scala
+// Before
+sealed abstract class Validation[-R, +V, -A, +B]:
+  def run(a: A): ZIO[R, Violations[V], B]
+
+// After
+sealed abstract class Validation[+V, -A, +B]:
+  def run(a: A): Either[Violations[V], B]
+```
+
+### ファクトリメソッド
+
+全メソッドから `R` パラメータを除去。ZIO API を Either / Try / パターンマッチに置換。
+
+| ZIO API | Either 対応 |
+|---------|------------|
+| `ZIO.succeed(x)` | `Right(x)` |
+| `ZIO.fail(v)` | `Left(v)` |
+| `ZIO.fromEither(e)` | `e`（そのまま） |
+| `ZIO.attempt(x).refineOrDie(...)` | `try ... catch ...` |
+| `for b <- run(a) yield ...` | `for b <- run(a) yield ...`（Either の flatMap） |
+| `.catchAll { e => ... }` | パターンマッチ |
+| `.mapError(f)` | `.left.map(f)` |
+
+### ValidateN（エラー蓄積）
+
+`zipPar` による並列実行を純粋な Either タプル合成に置換。
+
+```scala
+sealed trait ValidateTuple[V, T <: Tuple, Out <: Tuple]:
+  def validate(t: T): Either[Violations[V], Out]
+```
+
+`R` パラメータ消滅。`ZIO.succeed(Right(...))` の二重ラップが不要に。
+
+### ValidateAs / ValidatedAs
+
+```scala
+// Before
+sealed trait ValidatedAs[-A, +B]:
+  type Env
+  type Err
+  def run(a: A): ZIO[Env, Violations[Err], B]
+
+// After
+sealed trait ValidatedAs[-A, +B]:
+  type Err
+  def run(a: A): Either[Violations[Err], B]
+```
+
+`type Env` を除去。`.at()` 拡張は `Either[Violations[V], A]` 上の `.left.map` で実装。
+
+### Cursor
+
+`CursorValidateAs` と `CursorField` の戻り値型を `Either[Violations[va.Err], B]` に変更。
+`.mapError` → `.left.map`。ロジック自体の変更なし。
+
+### ValidationInstances（コレクション系）
+
+`ZIO.foreach(...).map(...).absolve` → `map` + `partitionMap` に簡素化。
+
+### build.sbt
+
+```scala
+lazy val core = (project in file("core"))
+  .settings(
+    libraryDependencies ++= Seq(
+      "dev.zio" %% "zio-test"          % zio % Test,
+      "dev.zio" %% "zio-test-sbt"      % zio % Test,
+      "dev.zio" %% "zio-test-magnolia" % zio % Test,
+    ),
+  )
+```
+
+compile スコープの `"dev.zio" %% "zio"` を除去。zio-test が推移的に含むためtest用の明示追加も不要。
+
+### テスト
+
+`ZIOSpecDefault` と `test()` をそのまま使用。`test()` は `Either` を直接受け付けるためラップ不要。
+
+### ドキュメント（docs/mdoc/index.md）
+
+`Unsafe.unsafe { Runtime.default.unsafe.run(...) }` → `Either` のパターンマッチに書き換え。
+
+## 変更対象ファイル一覧
+
+### core main（5ファイル）
+- `core/src/main/scala/yoshi/Validation.scala`
+- `core/src/main/scala/yoshi/Cursor.scala`
+- `core/src/main/scala/yoshi/syntax/ValidateN.scala`
+- `core/src/main/scala/yoshi/syntax/ValidateAs.scala`
+- `core/src/main/scala/yoshi/ValidationInstances.scala`
+
+### defaults（2ファイル — 型引数の機械的変更のみ）
+- `core/src/main/scala/yoshi/defaults/ValidationInstances.scala`
+- `core/src/main/scala/yoshi/defaults/Validations.scala`
+
+### build / docs
+- `build.sbt`
+- `docs/mdoc/index.md`
+
+### テスト（7ファイル）
+- `core/src/test/scala/yoshi/CursorSpec.scala`
+- `core/src/test/scala/yoshi/ValidationsSpec.scala`
+- `core/src/test/scala/yoshi/ValidationProductSpec.scala`
+- `core/src/test/scala/yoshi/ValidationCombinatorsSpec.scala`
+- `core/src/test/scala/yoshi/ValidationTransformsSpec.scala`
+- `core/src/test/scala/yoshi/ValidationTypeclassSpec.scala`
+- `core/src/test/scala/yoshi/ViolationsSpec.scala`
+
+### 変更なし
+- `core/src/main/scala/yoshi/Violations.scala`
+- `core/src/main/scala/yoshi/internal/FieldNameMacro.scala`
+- `core/src/main/scala/yoshi/defaults/Violation.scala`
+
+### スコープ外（コンパイル不可になるが後続対応）
+- `zio-prelude/` 配下の全ファイル

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "prepare": "husky"
+  },
+  "packageManager": "pnpm@10.33.0",
+  "devDependencies": {
+    "@commitlint/cli": "^20.5.0",
+    "@commitlint/config-conventional": "^20.5.0",
+    "husky": "^9.1.7"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,714 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@commitlint/cli':
+        specifier: ^20.5.0
+        version: 20.5.0(@types/node@25.6.0)(conventional-commits-parser@6.4.0)(typescript@6.0.2)
+      '@commitlint/config-conventional':
+        specifier: ^20.5.0
+        version: 20.5.0
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
+
+packages:
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@commitlint/cli@20.5.0':
+    resolution: {integrity: sha512-yNkyN/tuKTJS3wdVfsZ2tXDM4G4Gi7z+jW54Cki8N8tZqwKBltbIvUUrSbT4hz1bhW/h0CdR+5sCSpXD+wMKaQ==}
+    engines: {node: '>=v18'}
+    hasBin: true
+
+  '@commitlint/config-conventional@20.5.0':
+    resolution: {integrity: sha512-t3Ni88rFw1XMa4nZHgOKJ8fIAT9M2j5TnKyTqJzsxea7FUetlNdYFus9dz+MhIRZmc16P0PPyEfh6X2d/qw8SA==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/config-validator@20.5.0':
+    resolution: {integrity: sha512-T/Uh6iJUzyx7j35GmHWdIiGRQB+ouZDk0pwAaYq4SXgB54KZhFdJ0vYmxiW6AMYICTIWuyMxDBl1jK74oFp/Gw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/ensure@20.5.0':
+    resolution: {integrity: sha512-IpHqAUesBeW1EDDdjzJeaOxU9tnogLAyXLRBn03SHlj1SGENn2JGZqSWGkFvBJkJzfXAuCNtsoYzax+ZPS+puw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/execute-rule@20.0.0':
+    resolution: {integrity: sha512-xyCoOShoPuPL44gVa+5EdZsBVao/pNzpQhkzq3RdtlFdKZtjWcLlUFQHSWBuhk5utKYykeJPSz2i8ABHQA+ZZw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/format@20.5.0':
+    resolution: {integrity: sha512-TI9EwFU/qZWSK7a5qyXMpKPPv3qta7FO4tKW+Wt2al7sgMbLWTsAcDpX1cU8k16TRdsiiet9aOw0zpvRXNJu7Q==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/is-ignored@20.5.0':
+    resolution: {integrity: sha512-JWLarAsurHJhPozbuAH6GbP4p/hdOCoqS9zJMfqwswne+/GPs5V0+rrsfOkP68Y8PSLphwtFXV0EzJ+GTXTTGg==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/lint@20.5.0':
+    resolution: {integrity: sha512-jiM3hNUdu04jFBf1VgPdjtIPvbuVfDTBAc6L98AWcoLjF5sYqkulBHBzlVWll4rMF1T5zeQFB6r//a+s+BBKlA==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/load@20.5.0':
+    resolution: {integrity: sha512-sLhhYTL/KxeOTZjjabKDhwidGZan84XKK1+XFkwDYL/4883kIajcz/dZFAhBJmZPtL8+nBx6bnkzA95YxPeDPw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/message@20.4.3':
+    resolution: {integrity: sha512-6akwCYrzcrFcTYz9GyUaWlhisY4lmQ3KvrnabmhoeAV8nRH4dXJAh4+EUQ3uArtxxKQkvxJS78hNX2EU3USgxQ==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/parse@20.5.0':
+    resolution: {integrity: sha512-SeKWHBMk7YOTnnEWUhx+d1a9vHsjjuo6Uo1xRfPNfeY4bdYFasCH1dDpAv13Lyn+dDPOels+jP6D2GRZqzc5fA==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/read@20.5.0':
+    resolution: {integrity: sha512-JDEIJ2+GnWpK8QqwfmW7O42h0aycJEWNqcdkJnyzLD11nf9dW2dWLTVEa8Wtlo4IZFGLPATjR5neA5QlOvIH1w==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/resolve-extends@20.5.0':
+    resolution: {integrity: sha512-3SHPWUW2v0tyspCTcfSsYml0gses92l6TlogwzvM2cbxDgmhSRc+fldDjvGkCXJrjSM87BBaWYTPWwwyASZRrg==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/rules@20.5.0':
+    resolution: {integrity: sha512-5NdQXQEdnDPT5pK8O39ZA7HohzPRHEsDGU23cyVCNPQy4WegAbAwrQk3nIu7p2sl3dutPk8RZd91yKTrMTnRkQ==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/to-lines@20.0.0':
+    resolution: {integrity: sha512-2l9gmwiCRqZNWgV+pX1X7z4yP0b3ex/86UmUFgoRt672Ez6cAM2lOQeHFRUTuE6sPpi8XBCGnd8Kh3bMoyHwJw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/top-level@20.4.3':
+    resolution: {integrity: sha512-qD9xfP6dFg5jQ3NMrOhG0/w5y3bBUsVGyJvXxdWEwBm8hyx4WOk3kKXw28T5czBYvyeCVJgJJ6aoJZUWDpaacQ==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/types@20.5.0':
+    resolution: {integrity: sha512-ZJoS8oSq2CAZEpc/YI9SulLrdiIyXeHb/OGqGrkUP6Q7YV+0ouNAa7GjqRdXeQPncHQIDz/jbCTlHScvYvO/gA==}
+    engines: {node: '>=v18'}
+
+  '@conventional-changelog/git-client@2.7.0':
+    resolution: {integrity: sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      conventional-commits-filter: ^5.0.0
+      conventional-commits-parser: ^6.4.0
+    peerDependenciesMeta:
+      conventional-commits-filter:
+        optional: true
+      conventional-commits-parser:
+        optional: true
+
+  '@simple-libs/child-process-utils@1.0.2':
+    resolution: {integrity: sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==}
+    engines: {node: '>=18'}
+
+  '@simple-libs/stream-utils@1.2.0':
+    resolution: {integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==}
+    engines: {node: '>=18'}
+
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  array-ify@1.0.0:
+    resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  compare-func@2.0.0:
+    resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
+
+  conventional-changelog-angular@8.3.1:
+    resolution: {integrity: sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==}
+    engines: {node: '>=18'}
+
+  conventional-changelog-conventionalcommits@9.3.1:
+    resolution: {integrity: sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==}
+    engines: {node: '>=18'}
+
+  conventional-commits-parser@6.4.0:
+    resolution: {integrity: sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  cosmiconfig-typescript-loader@6.3.0:
+    resolution: {integrity: sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==}
+    engines: {node: '>=v18'}
+    peerDependencies:
+      '@types/node': '*'
+      cosmiconfig: '>=9'
+      typescript: '>=5'
+
+  cosmiconfig@9.0.1:
+    resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  dot-prop@5.3.0:
+    resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
+    engines: {node: '>=8'}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  git-raw-commits@5.0.1:
+    resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  global-directory@4.0.1:
+    resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
+    engines: {node: '>=18'}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
+  ini@4.1.1:
+    resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-obj@2.0.0:
+    resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
+    engines: {node: '>=8'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  lodash.kebabcase@4.1.1:
+    resolution: {integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==}
+
+  lodash.mergewith@4.6.2:
+    resolution: {integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==}
+
+  lodash.snakecase@4.1.1:
+    resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
+
+  lodash.startcase@4.4.0:
+    resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
+
+  lodash.upperfirst@4.3.1:
+    resolution: {integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==}
+
+  meow@13.2.0:
+    resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
+    engines: {node: '>=18'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
+
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
+snapshots:
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@commitlint/cli@20.5.0(@types/node@25.6.0)(conventional-commits-parser@6.4.0)(typescript@6.0.2)':
+    dependencies:
+      '@commitlint/format': 20.5.0
+      '@commitlint/lint': 20.5.0
+      '@commitlint/load': 20.5.0(@types/node@25.6.0)(typescript@6.0.2)
+      '@commitlint/read': 20.5.0(conventional-commits-parser@6.4.0)
+      '@commitlint/types': 20.5.0
+      tinyexec: 1.1.1
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - conventional-commits-filter
+      - conventional-commits-parser
+      - typescript
+
+  '@commitlint/config-conventional@20.5.0':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      conventional-changelog-conventionalcommits: 9.3.1
+
+  '@commitlint/config-validator@20.5.0':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      ajv: 8.18.0
+
+  '@commitlint/ensure@20.5.0':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      lodash.camelcase: 4.3.0
+      lodash.kebabcase: 4.1.1
+      lodash.snakecase: 4.1.1
+      lodash.startcase: 4.4.0
+      lodash.upperfirst: 4.3.1
+
+  '@commitlint/execute-rule@20.0.0': {}
+
+  '@commitlint/format@20.5.0':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      picocolors: 1.1.1
+
+  '@commitlint/is-ignored@20.5.0':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      semver: 7.7.4
+
+  '@commitlint/lint@20.5.0':
+    dependencies:
+      '@commitlint/is-ignored': 20.5.0
+      '@commitlint/parse': 20.5.0
+      '@commitlint/rules': 20.5.0
+      '@commitlint/types': 20.5.0
+
+  '@commitlint/load@20.5.0(@types/node@25.6.0)(typescript@6.0.2)':
+    dependencies:
+      '@commitlint/config-validator': 20.5.0
+      '@commitlint/execute-rule': 20.0.0
+      '@commitlint/resolve-extends': 20.5.0
+      '@commitlint/types': 20.5.0
+      cosmiconfig: 9.0.1(typescript@6.0.2)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@25.6.0)(cosmiconfig@9.0.1(typescript@6.0.2))(typescript@6.0.2)
+      is-plain-obj: 4.1.0
+      lodash.mergewith: 4.6.2
+      picocolors: 1.1.1
+    transitivePeerDependencies:
+      - '@types/node'
+      - typescript
+
+  '@commitlint/message@20.4.3': {}
+
+  '@commitlint/parse@20.5.0':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      conventional-changelog-angular: 8.3.1
+      conventional-commits-parser: 6.4.0
+
+  '@commitlint/read@20.5.0(conventional-commits-parser@6.4.0)':
+    dependencies:
+      '@commitlint/top-level': 20.4.3
+      '@commitlint/types': 20.5.0
+      git-raw-commits: 5.0.1(conventional-commits-parser@6.4.0)
+      minimist: 1.2.8
+      tinyexec: 1.1.1
+    transitivePeerDependencies:
+      - conventional-commits-filter
+      - conventional-commits-parser
+
+  '@commitlint/resolve-extends@20.5.0':
+    dependencies:
+      '@commitlint/config-validator': 20.5.0
+      '@commitlint/types': 20.5.0
+      global-directory: 4.0.1
+      import-meta-resolve: 4.2.0
+      lodash.mergewith: 4.6.2
+      resolve-from: 5.0.0
+
+  '@commitlint/rules@20.5.0':
+    dependencies:
+      '@commitlint/ensure': 20.5.0
+      '@commitlint/message': 20.4.3
+      '@commitlint/to-lines': 20.0.0
+      '@commitlint/types': 20.5.0
+
+  '@commitlint/to-lines@20.0.0': {}
+
+  '@commitlint/top-level@20.4.3':
+    dependencies:
+      escalade: 3.2.0
+
+  '@commitlint/types@20.5.0':
+    dependencies:
+      conventional-commits-parser: 6.4.0
+      picocolors: 1.1.1
+
+  '@conventional-changelog/git-client@2.7.0(conventional-commits-parser@6.4.0)':
+    dependencies:
+      '@simple-libs/child-process-utils': 1.0.2
+      '@simple-libs/stream-utils': 1.2.0
+      semver: 7.7.4
+    optionalDependencies:
+      conventional-commits-parser: 6.4.0
+
+  '@simple-libs/child-process-utils@1.0.2':
+    dependencies:
+      '@simple-libs/stream-utils': 1.2.0
+
+  '@simple-libs/stream-utils@1.2.0': {}
+
+  '@types/node@25.6.0':
+    dependencies:
+      undici-types: 7.19.2
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  argparse@2.0.1: {}
+
+  array-ify@1.0.0: {}
+
+  callsites@3.1.0: {}
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  compare-func@2.0.0:
+    dependencies:
+      array-ify: 1.0.0
+      dot-prop: 5.3.0
+
+  conventional-changelog-angular@8.3.1:
+    dependencies:
+      compare-func: 2.0.0
+
+  conventional-changelog-conventionalcommits@9.3.1:
+    dependencies:
+      compare-func: 2.0.0
+
+  conventional-commits-parser@6.4.0:
+    dependencies:
+      '@simple-libs/stream-utils': 1.2.0
+      meow: 13.2.0
+
+  cosmiconfig-typescript-loader@6.3.0(@types/node@25.6.0)(cosmiconfig@9.0.1(typescript@6.0.2))(typescript@6.0.2):
+    dependencies:
+      '@types/node': 25.6.0
+      cosmiconfig: 9.0.1(typescript@6.0.2)
+      jiti: 2.6.1
+      typescript: 6.0.2
+
+  cosmiconfig@9.0.1(typescript@6.0.2):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 6.0.2
+
+  dot-prop@5.3.0:
+    dependencies:
+      is-obj: 2.0.0
+
+  emoji-regex@8.0.0: {}
+
+  env-paths@2.2.1: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
+
+  escalade@3.2.0: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.0: {}
+
+  get-caller-file@2.0.5: {}
+
+  git-raw-commits@5.0.1(conventional-commits-parser@6.4.0):
+    dependencies:
+      '@conventional-changelog/git-client': 2.7.0(conventional-commits-parser@6.4.0)
+      meow: 13.2.0
+    transitivePeerDependencies:
+      - conventional-commits-filter
+      - conventional-commits-parser
+
+  global-directory@4.0.1:
+    dependencies:
+      ini: 4.1.1
+
+  husky@9.1.7: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  import-meta-resolve@4.2.0: {}
+
+  ini@4.1.1: {}
+
+  is-arrayish@0.2.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-obj@2.0.0: {}
+
+  is-plain-obj@4.1.0: {}
+
+  jiti@2.6.1: {}
+
+  js-tokens@4.0.0: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  json-parse-even-better-errors@2.3.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  lines-and-columns@1.2.4: {}
+
+  lodash.camelcase@4.3.0: {}
+
+  lodash.kebabcase@4.1.1: {}
+
+  lodash.mergewith@4.6.2: {}
+
+  lodash.snakecase@4.1.1: {}
+
+  lodash.startcase@4.4.0: {}
+
+  lodash.upperfirst@4.3.1: {}
+
+  meow@13.2.0: {}
+
+  minimist@1.2.8: {}
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
+  picocolors@1.1.1: {}
+
+  require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
+
+  resolve-from@4.0.0: {}
+
+  resolve-from@5.0.0: {}
+
+  semver@7.7.4: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  tinyexec@1.1.1: {}
+
+  typescript@6.0.2: {}
+
+  undici-types@7.19.2: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  y18n@5.0.8: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1

--- a/zio-prelude/src/main/scala/yoshi/AssociativeBothInstances.scala
+++ b/zio-prelude/src/main/scala/yoshi/AssociativeBothInstances.scala
@@ -1,18 +1,17 @@
 package yoshi
 
-import zio.ZIO
 import zio.prelude.AssociativeBoth
 
 private[yoshi] trait AssociativeBothInstances {
 
-  implicit def violationsAssociativeBoth[R, V]: AssociativeBoth[[X] =>> ZIO[R, Violations[V], X]] =
-    new AssociativeBoth[[X] =>> ZIO[R, Violations[V], X]] {
-      def both[A, B](fa: => ZIO[R, Violations[V], A], fb: => ZIO[R, Violations[V], B]): ZIO[R, Violations[V], (A, B)] =
-        (fa.either zip fb.either).flatMap {
-          case (Right(a), Right(b)) => ZIO.succeed((a, b))
-          case (Left(e1), Left(e2)) => ZIO.fail(e1 ++ e2)
-          case (Left(e), _)         => ZIO.fail(e)
-          case (_, Left(e))         => ZIO.fail(e)
+  implicit def violationsAssociativeBoth[V]: AssociativeBoth[[X] =>> Either[Violations[V], X]] =
+    new AssociativeBoth[[X] =>> Either[Violations[V], X]] {
+      def both[A, B](fa: => Either[Violations[V], A], fb: => Either[Violations[V], B]): Either[Violations[V], (A, B)] =
+        (fa, fb) match {
+          case (Right(a), Right(b)) => Right((a, b))
+          case (Left(e1), Left(e2)) => Left(e1 ++ e2)
+          case (Left(e), _)         => Left(e)
+          case (_, Left(e))         => Left(e)
         }
     }
 }

--- a/zio-prelude/src/main/scala/yoshi/NewtypeSyntax.scala
+++ b/zio-prelude/src/main/scala/yoshi/NewtypeSyntax.scala
@@ -1,17 +1,16 @@
 package yoshi
 
-import zio.ZIO
 import zio.prelude.Newtype
 
 private[yoshi] trait NewtypeSyntax {
 
   extension (self: Validation.type)
 
-    def newtype[V, A](nt: Newtype[A])(error: (A, String) => V): Validation[Any, V, A, nt.Type] =
+    def newtype[V, A](nt: Newtype[A])(error: (A, String) => V): Validation[V, A, nt.Type] =
       Validation.instance[A] { a =>
         nt.make(a).toEither match {
-          case Right(value) => ZIO.succeed(value)
-          case Left(errors) => ZIO.fail(Violations(errors.map(error(a, _)).toVector))
+          case Right(value) => Right(value)
+          case Left(errors) => Left(Violations(errors.map(error(a, _)).toVector))
         }
       }
 }

--- a/zio-prelude/src/main/scala/yoshi/NonEmptyChunkInstances.scala
+++ b/zio-prelude/src/main/scala/yoshi/NonEmptyChunkInstances.scala
@@ -2,31 +2,30 @@ package yoshi
 
 import zio.Chunk
 import zio.NonEmptyChunk
-import zio.ZIO
 import zio.prelude.{Validation as _, *}
 
 private[yoshi] trait NonEmptyChunkInstances { self: AssociativeBothInstances =>
 
-  implicit def chunkCanBeNonEmptyChunk[R, V, A](using
-    Validation[R, V, Option[NonEmptyChunk[A]], NonEmptyChunk[A]],
-  ): Validation[R, V, Chunk[A], NonEmptyChunk[A]] =
+  implicit def chunkCanBeNonEmptyChunk[V, A](using
+    Validation[V, Option[NonEmptyChunk[A]], NonEmptyChunk[A]],
+  ): Validation[V, Chunk[A], NonEmptyChunk[A]] =
     Validation.instance[Chunk[A]] { as =>
       NonEmptyChunk.fromIterableOption(as).validateAs[NonEmptyChunk[A]]
     }
 
-  implicit def nonEmptyChunkValidation[R, V, A, B](using
-    v: Validation[R, V, A, B],
-  ): Validation[R, V, NonEmptyChunk[A], NonEmptyChunk[B]] =
+  implicit def nonEmptyChunkValidation[V, A, B](using
+    v: Validation[V, A, B],
+  ): Validation[V, NonEmptyChunk[A], NonEmptyChunk[B]] =
     Validation.instance[NonEmptyChunk[A]] { nec =>
       nec.zipWithIndex.forEach1 { case (a, index) =>
         v.run(a).at(index)
       }
     }
 
-  implicit def chunkCanBeTransformedNonEmptyChunk[R, V, A, B](using
-    Validation[R, V, Option[NonEmptyChunk[A]], NonEmptyChunk[A]],
-    Validation[R, V, A, B],
-  ): Validation[R, V, Chunk[A], NonEmptyChunk[B]] = Validation.instance[Chunk[A]] { chunk =>
+  implicit def chunkCanBeTransformedNonEmptyChunk[V, A, B](using
+    Validation[V, Option[NonEmptyChunk[A]], NonEmptyChunk[A]],
+    Validation[V, A, B],
+  ): Validation[V, Chunk[A], NonEmptyChunk[B]] = Validation.instance[Chunk[A]] { chunk =>
     for {
       as <- chunk.validateAs[NonEmptyChunk[A]]
       bs <- as.validateAs[NonEmptyChunk[B]]

--- a/zio-prelude/src/main/scala/yoshi/NonEmptyListInstances.scala
+++ b/zio-prelude/src/main/scala/yoshi/NonEmptyListInstances.scala
@@ -1,30 +1,29 @@
 package yoshi
 
-import zio.ZIO
 import zio.prelude.{Validation as _, *}
 
 private[yoshi] trait NonEmptyListInstances { self: AssociativeBothInstances =>
 
-  implicit def listCanBeNonEmptyList[R, V, A](using
-    Validation[R, V, Option[NonEmptyList[A]], NonEmptyList[A]],
-  ): Validation[R, V, List[A], NonEmptyList[A]] =
+  implicit def listCanBeNonEmptyList[V, A](using
+    Validation[V, Option[NonEmptyList[A]], NonEmptyList[A]],
+  ): Validation[V, List[A], NonEmptyList[A]] =
     Validation.instance[List[A]] { list =>
       NonEmptyList.fromIterableOption(list).validateAs[NonEmptyList[A]]
     }
 
-  implicit def nonEmptyListValidation[R, V, A, B](using
-    v: Validation[R, V, A, B],
-  ): Validation[R, V, NonEmptyList[A], NonEmptyList[B]] =
+  implicit def nonEmptyListValidation[V, A, B](using
+    v: Validation[V, A, B],
+  ): Validation[V, NonEmptyList[A], NonEmptyList[B]] =
     Validation.instance[NonEmptyList[A]] { nel =>
       nel.zipWithIndex.forEach1 { case (a, index) =>
         v.run(a).at(index)
       }
     }
 
-  implicit def listCanBeTransformedNonEmptyList[R, V, A, B](using
-    Validation[R, V, Option[NonEmptyList[A]], NonEmptyList[A]],
-    Validation[R, V, A, B],
-  ): Validation[R, V, List[A], NonEmptyList[B]] = Validation.instance[List[A]] { list =>
+  implicit def listCanBeTransformedNonEmptyList[V, A, B](using
+    Validation[V, Option[NonEmptyList[A]], NonEmptyList[A]],
+    Validation[V, A, B],
+  ): Validation[V, List[A], NonEmptyList[B]] = Validation.instance[List[A]] { list =>
     for {
       as <- list.validateAs[NonEmptyList[A]]
       bs <- as.validateAs[NonEmptyList[B]]

--- a/zio-prelude/src/main/scala/yoshi/NonEmptySetInstances.scala
+++ b/zio-prelude/src/main/scala/yoshi/NonEmptySetInstances.scala
@@ -1,19 +1,18 @@
 package yoshi
 
-import zio.ZIO
 import zio.prelude.{Validation as _, *}
 
 private[yoshi] trait NonEmptySetInstances { self: NonEmptyListInstances =>
 
-  implicit def setCanBeNonEmptySet[R, V, A](using
-    Validation[R, V, Option[NonEmptySet[A]], NonEmptySet[A]],
-  ): Validation[R, V, Set[A], NonEmptySet[A]] = Validation.instance[Set[A]] { as =>
+  implicit def setCanBeNonEmptySet[V, A](using
+    Validation[V, Option[NonEmptySet[A]], NonEmptySet[A]],
+  ): Validation[V, Set[A], NonEmptySet[A]] = Validation.instance[Set[A]] { as =>
     NonEmptySet.fromIterableOption(as).validateAs[NonEmptySet[A]]
   }
 
-  implicit def nonEmptySetValidation[R, V, A, B](using
-    v: Validation[R, V, A, B],
-  ): Validation[R, V, NonEmptySet[A], NonEmptySet[B]] = Validation.instance[NonEmptySet[A]] { as =>
+  implicit def nonEmptySetValidation[V, A, B](using
+    v: Validation[V, A, B],
+  ): Validation[V, NonEmptySet[A], NonEmptySet[B]] = Validation.instance[NonEmptySet[A]] { as =>
     for {
       bs <- as.toNonEmptyList.validateAs[NonEmptyList[B]]
     } yield {
@@ -21,10 +20,10 @@ private[yoshi] trait NonEmptySetInstances { self: NonEmptyListInstances =>
     }
   }
 
-  implicit def setCanBeTransformedNonEmptySet[R, V, A, B](using
-    Validation[R, V, Option[NonEmptySet[A]], NonEmptySet[A]],
-    Validation[R, V, A, B],
-  ): Validation[R, V, Set[A], NonEmptySet[B]] = Validation.instance[Set[A]] { set =>
+  implicit def setCanBeTransformedNonEmptySet[V, A, B](using
+    Validation[V, Option[NonEmptySet[A]], NonEmptySet[A]],
+    Validation[V, A, B],
+  ): Validation[V, Set[A], NonEmptySet[B]] = Validation.instance[Set[A]] { set =>
     for {
       as <- set.validateAs[NonEmptySet[A]]
       bs <- as.validateAs[NonEmptySet[B]]

--- a/zio-prelude/src/test/scala/yoshi/NewtypeSyntaxSpec.scala
+++ b/zio-prelude/src/test/scala/yoshi/NewtypeSyntaxSpec.scala
@@ -25,29 +25,25 @@ object NewtypeSyntaxSpec extends ZIOSpecDefault {
   override def spec = suiteAll("Validation.newtype") {
     test("succeeds for Newtype with default assertion") {
       val v = Validation.newtype(WrappedString)((value, msg) => s"$value: $msg")
-      for result <- v.run("anything")
-      yield assertTrue(result == WrappedString("anything"))
+      assertTrue(v.run("anything") == Right(WrappedString("anything")))
     }
     test("succeeds when custom assertion passes") {
       val v = Validation.newtype(PositiveInt)((value, _) => s"$value must be positive")
-      for result <- v.run(5)
-      yield assertTrue(result == PositiveInt(5))
+      assertTrue(v.run(5) == Right(PositiveInt(5)))
     }
     test("fails with caller-defined violation when assertion fails") {
       val v = Validation.newtype(PositiveInt)((value, _) => s"$value must be positive")
-      for result <- v.run(0).either
-      yield assertTrue(result.is(_.left) == Violations.of("0 must be positive"))
+      assertTrue(v.run(0) == Left(Violations.of("0 must be positive")))
     }
     test("fails with compound assertion") {
-      val v = Validation.newtype(BoundedInt)((value, msg) => s"$value: $msg")
-      for result <- v.run(200).either
-      yield assertTrue(result.is(_.left).values.nonEmpty)
+      val v                = Validation.newtype(BoundedInt)((value, msg) => s"$value: $msg")
+      val Left(violations) = v.run(200): @unchecked
+      assertTrue(violations.values.nonEmpty)
     }
     test("composes with >> for String to newtype") {
-      val v: Validation[Any, Violation, String, PositiveInt] =
+      val v: Validation[Violation, String, PositiveInt] =
         Validations.parseInt >> Validation.newtype(PositiveInt)((value, _) => Violation.NonPositive(value))
-      for result <- v.run("42")
-      yield assertTrue(result == PositiveInt(42))
+      assertTrue(v.run("42") == Right(PositiveInt(42)))
     }
   }
 }

--- a/zio-prelude/src/test/scala/yoshi/NewtypeSyntaxSpec.scala
+++ b/zio-prelude/src/test/scala/yoshi/NewtypeSyntaxSpec.scala
@@ -25,15 +25,17 @@ object NewtypeSyntaxSpec extends ZIOSpecDefault {
   override def spec = suiteAll("Validation.newtype") {
     test("succeeds for Newtype with default assertion") {
       val v = Validation.newtype(WrappedString)((value, msg) => s"$value: $msg")
-      assertTrue(v.run("anything") == Right(WrappedString("anything")))
+      assertTrue(
+        v.run("anything").is(_.right) == WrappedString("anything"),
+      )
     }
     test("succeeds when custom assertion passes") {
       val v = Validation.newtype(PositiveInt)((value, _) => s"$value must be positive")
-      assertTrue(v.run(5) == Right(PositiveInt(5)))
+      assertTrue(v.run(5).is(_.right) == PositiveInt(5))
     }
     test("fails with caller-defined violation when assertion fails") {
       val v = Validation.newtype(PositiveInt)((value, _) => s"$value must be positive")
-      assertTrue(v.run(0) == Left(Violations.of("0 must be positive")))
+      assertTrue(v.run(0).is(_.left) == Violations.of("0 must be positive"))
     }
     test("fails with compound assertion") {
       val v                = Validation.newtype(BoundedInt)((value, msg) => s"$value: $msg")
@@ -43,7 +45,7 @@ object NewtypeSyntaxSpec extends ZIOSpecDefault {
     test("composes with >> for String to newtype") {
       val v: Validation[Violation, String, PositiveInt] =
         Validations.parseInt >> Validation.newtype(PositiveInt)((value, _) => Violation.NonPositive(value))
-      assertTrue(v.run("42") == Right(PositiveInt(42)))
+      assertTrue(v.run("42").is(_.right) == PositiveInt(42))
     }
   }
 }

--- a/zio-prelude/src/test/scala/yoshi/NewtypeSyntaxSpec.scala
+++ b/zio-prelude/src/test/scala/yoshi/NewtypeSyntaxSpec.scala
@@ -25,13 +25,19 @@ object NewtypeSyntaxSpec extends ZIOSpecDefault {
   override def spec = suiteAll("Validation.newtype") {
     test("succeeds for Newtype with default assertion") {
       val v = Validation.newtype(WrappedString)((value, msg) => s"$value: $msg")
-      assertTrue(
-        v.run("anything").is(_.right) == WrappedString("anything"),
-      )
+      for {
+        result <- v.run("anything")
+      } yield {
+        assertTrue(result == WrappedString("anything"))
+      }
     }
     test("succeeds when custom assertion passes") {
       val v = Validation.newtype(PositiveInt)((value, _) => s"$value must be positive")
-      assertTrue(v.run(5).is(_.right) == PositiveInt(5))
+      for {
+        result <- v.run(5)
+      } yield {
+        assertTrue(result == PositiveInt(5))
+      }
     }
     test("fails with caller-defined violation when assertion fails") {
       val v = Validation.newtype(PositiveInt)((value, _) => s"$value must be positive")
@@ -45,7 +51,11 @@ object NewtypeSyntaxSpec extends ZIOSpecDefault {
     test("composes with >> for String to newtype") {
       val v: Validation[Violation, String, PositiveInt] =
         Validations.parseInt >> Validation.newtype(PositiveInt)((value, _) => Violation.NonPositive(value))
-      assertTrue(v.run("42").is(_.right) == PositiveInt(42))
+      for {
+        result <- v.run("42")
+      } yield {
+        assertTrue(result == PositiveInt(42))
+      }
     }
   }
 }

--- a/zio-prelude/src/test/scala/yoshi/NonEmptyChunkSpec.scala
+++ b/zio-prelude/src/test/scala/yoshi/NonEmptyChunkSpec.scala
@@ -11,51 +11,47 @@ object NonEmptyChunkSpec extends ZIOSpecDefault {
   override def spec = suiteAll("NonEmptyChunk") {
     suiteAll("Chunk → NonEmptyChunk") {
       test("succeeds with non-empty chunk") {
-        assertTrue(Chunk(1, 2, 3).validateAs[NonEmptyChunk[Int]] == Right(NonEmptyChunk(1, 2, 3)))
+        assertTrue(Chunk(1, 2, 3).validateAs[NonEmptyChunk[Int]].is(_.right) == NonEmptyChunk(1, 2, 3))
       }
       test("fails with Violation.Required on empty chunk") {
-        assertTrue(Chunk.empty[Int].validateAs[NonEmptyChunk[Int]] == Left(Violations.of(Violation.Required)))
+        assertTrue(Chunk.empty[Int].validateAs[NonEmptyChunk[Int]].is(_.left) == Violations.of(Violation.Required))
       }
       test("succeeds with single element") {
-        assertTrue(Chunk(42).validateAs[NonEmptyChunk[Int]] == Right(NonEmptyChunk(42)))
+        assertTrue(Chunk(42).validateAs[NonEmptyChunk[Int]].is(_.right) == NonEmptyChunk(42))
       }
     }
     suiteAll("Chunk → NonEmptyChunk (element transform)") {
       test("transforms all elements") {
-        assertTrue(Chunk("1", "2", "3").validateAs[NonEmptyChunk[Int]] == Right(NonEmptyChunk(1, 2, 3)))
+        assertTrue(Chunk("1", "2", "3").validateAs[NonEmptyChunk[Int]].is(_.right) == NonEmptyChunk(1, 2, 3))
       }
       test("fails at index 0 when head transformation fails") {
         assertTrue(
-          Chunk("abc", "2").validateAs[NonEmptyChunk[Int]] == Left(
+          Chunk("abc", "2").validateAs[NonEmptyChunk[Int]].is(_.left) ==
             Violations.of(Violation.NonIntegerString("abc")).asChild(0),
-          ),
         )
       }
       test("fails at index 1 when tail transformation fails") {
         assertTrue(
-          Chunk("1", "abc").validateAs[NonEmptyChunk[Int]] == Left(
+          Chunk("1", "abc").validateAs[NonEmptyChunk[Int]].is(_.left) ==
             Violations.of(Violation.NonIntegerString("abc")).asChild(1),
-          ),
         )
       }
     }
     suiteAll("NonEmptyChunk element transform") {
       test("transforms all elements") {
-        assertTrue(NonEmptyChunk("1", "2", "3").validateAs[NonEmptyChunk[Int]] == Right(NonEmptyChunk(1, 2, 3)))
+        assertTrue(NonEmptyChunk("1", "2", "3").validateAs[NonEmptyChunk[Int]].is(_.right) == NonEmptyChunk(1, 2, 3))
       }
       test("fails at the index of the invalid element") {
         assertTrue(
-          NonEmptyChunk("1", "abc").validateAs[NonEmptyChunk[Int]] == Left(
+          NonEmptyChunk("1", "abc").validateAs[NonEmptyChunk[Int]].is(_.left) ==
             Violations.of(Violation.NonIntegerString("abc")).asChild(1),
-          ),
         )
       }
       test("accumulates violations from multiple invalid elements") {
         assertTrue(
-          NonEmptyChunk("abc", "def").validateAs[NonEmptyChunk[Int]] == Left(
+          NonEmptyChunk("abc", "def").validateAs[NonEmptyChunk[Int]].is(_.left) ==
             Violations.of(Violation.NonIntegerString("abc")).asChild(0) ++
-              Violations.of(Violation.NonIntegerString("def")).asChild(1),
-          ),
+            Violations.of(Violation.NonIntegerString("def")).asChild(1),
         )
       }
     }

--- a/zio-prelude/src/test/scala/yoshi/NonEmptyChunkSpec.scala
+++ b/zio-prelude/src/test/scala/yoshi/NonEmptyChunkSpec.scala
@@ -11,18 +11,30 @@ object NonEmptyChunkSpec extends ZIOSpecDefault {
   override def spec = suiteAll("NonEmptyChunk") {
     suiteAll("Chunk → NonEmptyChunk") {
       test("succeeds with non-empty chunk") {
-        assertTrue(Chunk(1, 2, 3).validateAs[NonEmptyChunk[Int]].is(_.right) == NonEmptyChunk(1, 2, 3))
+        for {
+          result <- Chunk(1, 2, 3).validateAs[NonEmptyChunk[Int]]
+        } yield {
+          assertTrue(result == NonEmptyChunk(1, 2, 3))
+        }
       }
       test("fails with Violation.Required on empty chunk") {
         assertTrue(Chunk.empty[Int].validateAs[NonEmptyChunk[Int]].is(_.left) == Violations.of(Violation.Required))
       }
       test("succeeds with single element") {
-        assertTrue(Chunk(42).validateAs[NonEmptyChunk[Int]].is(_.right) == NonEmptyChunk(42))
+        for {
+          result <- Chunk(42).validateAs[NonEmptyChunk[Int]]
+        } yield {
+          assertTrue(result == NonEmptyChunk(42))
+        }
       }
     }
     suiteAll("Chunk → NonEmptyChunk (element transform)") {
       test("transforms all elements") {
-        assertTrue(Chunk("1", "2", "3").validateAs[NonEmptyChunk[Int]].is(_.right) == NonEmptyChunk(1, 2, 3))
+        for {
+          result <- Chunk("1", "2", "3").validateAs[NonEmptyChunk[Int]]
+        } yield {
+          assertTrue(result == NonEmptyChunk(1, 2, 3))
+        }
       }
       test("fails at index 0 when head transformation fails") {
         assertTrue(
@@ -39,7 +51,11 @@ object NonEmptyChunkSpec extends ZIOSpecDefault {
     }
     suiteAll("NonEmptyChunk element transform") {
       test("transforms all elements") {
-        assertTrue(NonEmptyChunk("1", "2", "3").validateAs[NonEmptyChunk[Int]].is(_.right) == NonEmptyChunk(1, 2, 3))
+        for {
+          result <- NonEmptyChunk("1", "2", "3").validateAs[NonEmptyChunk[Int]]
+        } yield {
+          assertTrue(result == NonEmptyChunk(1, 2, 3))
+        }
       }
       test("fails at the index of the invalid element") {
         assertTrue(

--- a/zio-prelude/src/test/scala/yoshi/NonEmptyChunkSpec.scala
+++ b/zio-prelude/src/test/scala/yoshi/NonEmptyChunkSpec.scala
@@ -11,47 +11,51 @@ object NonEmptyChunkSpec extends ZIOSpecDefault {
   override def spec = suiteAll("NonEmptyChunk") {
     suiteAll("Chunk → NonEmptyChunk") {
       test("succeeds with non-empty chunk") {
-        for result <- Chunk(1, 2, 3).validateAs[NonEmptyChunk[Int]]
-        yield assertTrue(result == NonEmptyChunk(1, 2, 3))
+        assertTrue(Chunk(1, 2, 3).validateAs[NonEmptyChunk[Int]] == Right(NonEmptyChunk(1, 2, 3)))
       }
       test("fails with Violation.Required on empty chunk") {
-        for result <- Chunk.empty[Int].validateAs[NonEmptyChunk[Int]].either
-        yield assertTrue(result.is(_.left) == Violations.of(Violation.Required))
+        assertTrue(Chunk.empty[Int].validateAs[NonEmptyChunk[Int]] == Left(Violations.of(Violation.Required)))
       }
       test("succeeds with single element") {
-        for result <- Chunk(42).validateAs[NonEmptyChunk[Int]]
-        yield assertTrue(result == NonEmptyChunk(42))
+        assertTrue(Chunk(42).validateAs[NonEmptyChunk[Int]] == Right(NonEmptyChunk(42)))
       }
     }
     suiteAll("Chunk → NonEmptyChunk (element transform)") {
       test("transforms all elements") {
-        for result <- Chunk("1", "2", "3").validateAs[NonEmptyChunk[Int]]
-        yield assertTrue(result == NonEmptyChunk(1, 2, 3))
+        assertTrue(Chunk("1", "2", "3").validateAs[NonEmptyChunk[Int]] == Right(NonEmptyChunk(1, 2, 3)))
       }
       test("fails at index 0 when head transformation fails") {
-        for result <- Chunk("abc", "2").validateAs[NonEmptyChunk[Int]].either
-        yield assertTrue(result.is(_.left) == Violations.of(Violation.NonIntegerString("abc")).asChild(0))
+        assertTrue(
+          Chunk("abc", "2").validateAs[NonEmptyChunk[Int]] == Left(
+            Violations.of(Violation.NonIntegerString("abc")).asChild(0),
+          ),
+        )
       }
       test("fails at index 1 when tail transformation fails") {
-        for result <- Chunk("1", "abc").validateAs[NonEmptyChunk[Int]].either
-        yield assertTrue(result.is(_.left) == Violations.of(Violation.NonIntegerString("abc")).asChild(1))
+        assertTrue(
+          Chunk("1", "abc").validateAs[NonEmptyChunk[Int]] == Left(
+            Violations.of(Violation.NonIntegerString("abc")).asChild(1),
+          ),
+        )
       }
     }
     suiteAll("NonEmptyChunk element transform") {
       test("transforms all elements") {
-        for result <- NonEmptyChunk("1", "2", "3").validateAs[NonEmptyChunk[Int]]
-        yield assertTrue(result == NonEmptyChunk(1, 2, 3))
+        assertTrue(NonEmptyChunk("1", "2", "3").validateAs[NonEmptyChunk[Int]] == Right(NonEmptyChunk(1, 2, 3)))
       }
       test("fails at the index of the invalid element") {
-        for result <- NonEmptyChunk("1", "abc").validateAs[NonEmptyChunk[Int]].either
-        yield assertTrue(result.is(_.left) == Violations.of(Violation.NonIntegerString("abc")).asChild(1))
+        assertTrue(
+          NonEmptyChunk("1", "abc").validateAs[NonEmptyChunk[Int]] == Left(
+            Violations.of(Violation.NonIntegerString("abc")).asChild(1),
+          ),
+        )
       }
       test("accumulates violations from multiple invalid elements") {
-        for result <- NonEmptyChunk("abc", "def").validateAs[NonEmptyChunk[Int]].either
-        yield assertTrue(
-          result.is(_.left) ==
+        assertTrue(
+          NonEmptyChunk("abc", "def").validateAs[NonEmptyChunk[Int]] == Left(
             Violations.of(Violation.NonIntegerString("abc")).asChild(0) ++
-            Violations.of(Violation.NonIntegerString("def")).asChild(1),
+              Violations.of(Violation.NonIntegerString("def")).asChild(1),
+          ),
         )
       }
     }

--- a/zio-prelude/src/test/scala/yoshi/NonEmptyListSpec.scala
+++ b/zio-prelude/src/test/scala/yoshi/NonEmptyListSpec.scala
@@ -10,51 +10,47 @@ object NonEmptyListSpec extends ZIOSpecDefault {
   override def spec = suiteAll("NonEmptyList") {
     suiteAll("List → NonEmptyList") {
       test("succeeds with non-empty list") {
-        assertTrue(List(1, 2, 3).validateAs[NonEmptyList[Int]] == Right(NonEmptyList(1, 2, 3)))
+        assertTrue(List(1, 2, 3).validateAs[NonEmptyList[Int]].is(_.right) == NonEmptyList(1, 2, 3))
       }
       test("fails with Violation.Required on empty list") {
-        assertTrue(List.empty[Int].validateAs[NonEmptyList[Int]] == Left(Violations.of(Violation.Required)))
+        assertTrue(List.empty[Int].validateAs[NonEmptyList[Int]].is(_.left) == Violations.of(Violation.Required))
       }
       test("succeeds with single element") {
-        assertTrue(List(42).validateAs[NonEmptyList[Int]] == Right(NonEmptyList(42)))
+        assertTrue(List(42).validateAs[NonEmptyList[Int]].is(_.right) == NonEmptyList(42))
       }
     }
     suiteAll("List → NonEmptyList (element transform)") {
       test("transforms all elements") {
-        assertTrue(List("1", "2", "3").validateAs[NonEmptyList[Int]] == Right(NonEmptyList(1, 2, 3)))
+        assertTrue(List("1", "2", "3").validateAs[NonEmptyList[Int]].is(_.right) == NonEmptyList(1, 2, 3))
       }
       test("fails at index 0 when head transformation fails") {
         assertTrue(
-          List("abc", "2").validateAs[NonEmptyList[Int]] == Left(
+          List("abc", "2").validateAs[NonEmptyList[Int]].is(_.left) ==
             Violations.of(Violation.NonIntegerString("abc")).asChild(0),
-          ),
         )
       }
       test("fails at index 1 when tail transformation fails") {
         assertTrue(
-          List("1", "abc").validateAs[NonEmptyList[Int]] == Left(
+          List("1", "abc").validateAs[NonEmptyList[Int]].is(_.left) ==
             Violations.of(Violation.NonIntegerString("abc")).asChild(1),
-          ),
         )
       }
     }
     suiteAll("NonEmptyList element transform") {
       test("transforms all elements") {
-        assertTrue(NonEmptyList("1", "2", "3").validateAs[NonEmptyList[Int]] == Right(NonEmptyList(1, 2, 3)))
+        assertTrue(NonEmptyList("1", "2", "3").validateAs[NonEmptyList[Int]].is(_.right) == NonEmptyList(1, 2, 3))
       }
       test("fails at the index of the invalid element") {
         assertTrue(
-          NonEmptyList("1", "abc").validateAs[NonEmptyList[Int]] == Left(
+          NonEmptyList("1", "abc").validateAs[NonEmptyList[Int]].is(_.left) ==
             Violations.of(Violation.NonIntegerString("abc")).asChild(1),
-          ),
         )
       }
       test("accumulates violations from multiple invalid elements") {
         assertTrue(
-          NonEmptyList("abc", "def").validateAs[NonEmptyList[Int]] == Left(
+          NonEmptyList("abc", "def").validateAs[NonEmptyList[Int]].is(_.left) ==
             Violations.of(Violation.NonIntegerString("abc")).asChild(0) ++
-              Violations.of(Violation.NonIntegerString("def")).asChild(1),
-          ),
+            Violations.of(Violation.NonIntegerString("def")).asChild(1),
         )
       }
     }

--- a/zio-prelude/src/test/scala/yoshi/NonEmptyListSpec.scala
+++ b/zio-prelude/src/test/scala/yoshi/NonEmptyListSpec.scala
@@ -10,18 +10,30 @@ object NonEmptyListSpec extends ZIOSpecDefault {
   override def spec = suiteAll("NonEmptyList") {
     suiteAll("List → NonEmptyList") {
       test("succeeds with non-empty list") {
-        assertTrue(List(1, 2, 3).validateAs[NonEmptyList[Int]].is(_.right) == NonEmptyList(1, 2, 3))
+        for {
+          result <- List(1, 2, 3).validateAs[NonEmptyList[Int]]
+        } yield {
+          assertTrue(result == NonEmptyList(1, 2, 3))
+        }
       }
       test("fails with Violation.Required on empty list") {
         assertTrue(List.empty[Int].validateAs[NonEmptyList[Int]].is(_.left) == Violations.of(Violation.Required))
       }
       test("succeeds with single element") {
-        assertTrue(List(42).validateAs[NonEmptyList[Int]].is(_.right) == NonEmptyList(42))
+        for {
+          result <- List(42).validateAs[NonEmptyList[Int]]
+        } yield {
+          assertTrue(result == NonEmptyList(42))
+        }
       }
     }
     suiteAll("List → NonEmptyList (element transform)") {
       test("transforms all elements") {
-        assertTrue(List("1", "2", "3").validateAs[NonEmptyList[Int]].is(_.right) == NonEmptyList(1, 2, 3))
+        for {
+          result <- List("1", "2", "3").validateAs[NonEmptyList[Int]]
+        } yield {
+          assertTrue(result == NonEmptyList(1, 2, 3))
+        }
       }
       test("fails at index 0 when head transformation fails") {
         assertTrue(
@@ -38,7 +50,11 @@ object NonEmptyListSpec extends ZIOSpecDefault {
     }
     suiteAll("NonEmptyList element transform") {
       test("transforms all elements") {
-        assertTrue(NonEmptyList("1", "2", "3").validateAs[NonEmptyList[Int]].is(_.right) == NonEmptyList(1, 2, 3))
+        for {
+          result <- NonEmptyList("1", "2", "3").validateAs[NonEmptyList[Int]]
+        } yield {
+          assertTrue(result == NonEmptyList(1, 2, 3))
+        }
       }
       test("fails at the index of the invalid element") {
         assertTrue(

--- a/zio-prelude/src/test/scala/yoshi/NonEmptyListSpec.scala
+++ b/zio-prelude/src/test/scala/yoshi/NonEmptyListSpec.scala
@@ -10,47 +10,51 @@ object NonEmptyListSpec extends ZIOSpecDefault {
   override def spec = suiteAll("NonEmptyList") {
     suiteAll("List → NonEmptyList") {
       test("succeeds with non-empty list") {
-        for result <- List(1, 2, 3).validateAs[NonEmptyList[Int]]
-        yield assertTrue(result == NonEmptyList(1, 2, 3))
+        assertTrue(List(1, 2, 3).validateAs[NonEmptyList[Int]] == Right(NonEmptyList(1, 2, 3)))
       }
       test("fails with Violation.Required on empty list") {
-        for result <- List.empty[Int].validateAs[NonEmptyList[Int]].either
-        yield assertTrue(result.is(_.left) == Violations.of(Violation.Required))
+        assertTrue(List.empty[Int].validateAs[NonEmptyList[Int]] == Left(Violations.of(Violation.Required)))
       }
       test("succeeds with single element") {
-        for result <- List(42).validateAs[NonEmptyList[Int]]
-        yield assertTrue(result == NonEmptyList(42))
+        assertTrue(List(42).validateAs[NonEmptyList[Int]] == Right(NonEmptyList(42)))
       }
     }
     suiteAll("List → NonEmptyList (element transform)") {
       test("transforms all elements") {
-        for result <- List("1", "2", "3").validateAs[NonEmptyList[Int]]
-        yield assertTrue(result == NonEmptyList(1, 2, 3))
+        assertTrue(List("1", "2", "3").validateAs[NonEmptyList[Int]] == Right(NonEmptyList(1, 2, 3)))
       }
       test("fails at index 0 when head transformation fails") {
-        for result <- List("abc", "2").validateAs[NonEmptyList[Int]].either
-        yield assertTrue(result.is(_.left) == Violations.of(Violation.NonIntegerString("abc")).asChild(0))
+        assertTrue(
+          List("abc", "2").validateAs[NonEmptyList[Int]] == Left(
+            Violations.of(Violation.NonIntegerString("abc")).asChild(0),
+          ),
+        )
       }
       test("fails at index 1 when tail transformation fails") {
-        for result <- List("1", "abc").validateAs[NonEmptyList[Int]].either
-        yield assertTrue(result.is(_.left) == Violations.of(Violation.NonIntegerString("abc")).asChild(1))
+        assertTrue(
+          List("1", "abc").validateAs[NonEmptyList[Int]] == Left(
+            Violations.of(Violation.NonIntegerString("abc")).asChild(1),
+          ),
+        )
       }
     }
     suiteAll("NonEmptyList element transform") {
       test("transforms all elements") {
-        for result <- NonEmptyList("1", "2", "3").validateAs[NonEmptyList[Int]]
-        yield assertTrue(result == NonEmptyList(1, 2, 3))
+        assertTrue(NonEmptyList("1", "2", "3").validateAs[NonEmptyList[Int]] == Right(NonEmptyList(1, 2, 3)))
       }
       test("fails at the index of the invalid element") {
-        for result <- NonEmptyList("1", "abc").validateAs[NonEmptyList[Int]].either
-        yield assertTrue(result.is(_.left) == Violations.of(Violation.NonIntegerString("abc")).asChild(1))
+        assertTrue(
+          NonEmptyList("1", "abc").validateAs[NonEmptyList[Int]] == Left(
+            Violations.of(Violation.NonIntegerString("abc")).asChild(1),
+          ),
+        )
       }
       test("accumulates violations from multiple invalid elements") {
-        for result <- NonEmptyList("abc", "def").validateAs[NonEmptyList[Int]].either
-        yield assertTrue(
-          result.is(_.left) ==
+        assertTrue(
+          NonEmptyList("abc", "def").validateAs[NonEmptyList[Int]] == Left(
             Violations.of(Violation.NonIntegerString("abc")).asChild(0) ++
-            Violations.of(Violation.NonIntegerString("def")).asChild(1),
+              Violations.of(Violation.NonIntegerString("def")).asChild(1),
+          ),
         )
       }
     }

--- a/zio-prelude/src/test/scala/yoshi/NonEmptySetSpec.scala
+++ b/zio-prelude/src/test/scala/yoshi/NonEmptySetSpec.scala
@@ -10,18 +10,30 @@ object NonEmptySetSpec extends ZIOSpecDefault {
   override def spec = suiteAll("NonEmptySet") {
     suiteAll("Set → NonEmptySet") {
       test("succeeds with non-empty set") {
-        assertTrue(Set(1, 2, 3).validateAs[NonEmptySet[Int]].is(_.right) == NonEmptySet(1, 2, 3))
+        for {
+          result <- Set(1, 2, 3).validateAs[NonEmptySet[Int]]
+        } yield {
+          assertTrue(result == NonEmptySet(1, 2, 3))
+        }
       }
       test("fails with Violation.Required on empty set") {
         assertTrue(Set.empty[Int].validateAs[NonEmptySet[Int]].is(_.left) == Violations.of(Violation.Required))
       }
       test("succeeds with single element") {
-        assertTrue(Set(42).validateAs[NonEmptySet[Int]].is(_.right) == NonEmptySet(42))
+        for {
+          result <- Set(42).validateAs[NonEmptySet[Int]]
+        } yield {
+          assertTrue(result == NonEmptySet(42))
+        }
       }
     }
     suiteAll("Set → NonEmptySet (element transform)") {
       test("transforms all elements") {
-        assertTrue(Set("1", "2", "3").validateAs[NonEmptySet[Int]].is(_.right) == NonEmptySet(1, 2, 3))
+        for {
+          result <- Set("1", "2", "3").validateAs[NonEmptySet[Int]]
+        } yield {
+          assertTrue(result == NonEmptySet(1, 2, 3))
+        }
       }
       test("fails only for invalid elements in a mixed set") {
         val Left(result) = Set("abc", "2").validateAs[NonEmptySet[Int]]: @unchecked
@@ -34,7 +46,11 @@ object NonEmptySetSpec extends ZIOSpecDefault {
     }
     suiteAll("NonEmptySet element transform") {
       test("transforms all elements") {
-        assertTrue(NonEmptySet("1", "2", "3").validateAs[NonEmptySet[Int]].is(_.right) == NonEmptySet(1, 2, 3))
+        for {
+          result <- NonEmptySet("1", "2", "3").validateAs[NonEmptySet[Int]]
+        } yield {
+          assertTrue(result == NonEmptySet(1, 2, 3))
+        }
       }
       test("fails when element transformation fails") {
         val Left(result) = NonEmptySet("abc").validateAs[NonEmptySet[Int]]: @unchecked

--- a/zio-prelude/src/test/scala/yoshi/NonEmptySetSpec.scala
+++ b/zio-prelude/src/test/scala/yoshi/NonEmptySetSpec.scala
@@ -10,59 +10,48 @@ object NonEmptySetSpec extends ZIOSpecDefault {
   override def spec = suiteAll("NonEmptySet") {
     suiteAll("Set → NonEmptySet") {
       test("succeeds with non-empty set") {
-        for result <- Set(1, 2, 3).validateAs[NonEmptySet[Int]]
-        yield assertTrue(result == NonEmptySet(1, 2, 3))
+        assertTrue(Set(1, 2, 3).validateAs[NonEmptySet[Int]] == Right(NonEmptySet(1, 2, 3)))
       }
       test("fails with Violation.Required on empty set") {
-        for result <- Set.empty[Int].validateAs[NonEmptySet[Int]].either
-        yield assertTrue(result.is(_.left) == Violations.of(Violation.Required))
+        assertTrue(Set.empty[Int].validateAs[NonEmptySet[Int]] == Left(Violations.of(Violation.Required)))
       }
       test("succeeds with single element") {
-        for result <- Set(42).validateAs[NonEmptySet[Int]]
-        yield assertTrue(result == NonEmptySet(42))
+        assertTrue(Set(42).validateAs[NonEmptySet[Int]] == Right(NonEmptySet(42)))
       }
     }
     suiteAll("Set → NonEmptySet (element transform)") {
       test("transforms all elements") {
-        for result <- Set("1", "2", "3").validateAs[NonEmptySet[Int]]
-        yield assertTrue(result == NonEmptySet(1, 2, 3))
+        assertTrue(Set("1", "2", "3").validateAs[NonEmptySet[Int]] == Right(NonEmptySet(1, 2, 3)))
       }
       test("fails only for invalid elements in a mixed set") {
-        for result <- Set("abc", "2").validateAs[NonEmptySet[Int]].flip
-        yield {
-          val violations = result.toList.map(_._2)
-          assertTrue(
-            violations.length == 1,
-            violations.contains(Violation.NonIntegerString("abc")),
-          )
-        }
+        val Left(result) = Set("abc", "2").validateAs[NonEmptySet[Int]]: @unchecked
+        val violations   = result.toList.map(_._2)
+        assertTrue(
+          violations.length == 1,
+          violations.contains(Violation.NonIntegerString("abc")),
+        )
       }
     }
     suiteAll("NonEmptySet element transform") {
       test("transforms all elements") {
-        for result <- NonEmptySet("1", "2", "3").validateAs[NonEmptySet[Int]]
-        yield assertTrue(result == NonEmptySet(1, 2, 3))
+        assertTrue(NonEmptySet("1", "2", "3").validateAs[NonEmptySet[Int]] == Right(NonEmptySet(1, 2, 3)))
       }
       test("fails when element transformation fails") {
-        for result <- NonEmptySet("abc").validateAs[NonEmptySet[Int]].flip
-        yield {
-          val violations = result.toList.map(_._2)
-          assertTrue(
-            violations.length == 1,
-            violations.contains(Violation.NonIntegerString("abc")),
-          )
-        }
+        val Left(result) = NonEmptySet("abc").validateAs[NonEmptySet[Int]]: @unchecked
+        val violations   = result.toList.map(_._2)
+        assertTrue(
+          violations.length == 1,
+          violations.contains(Violation.NonIntegerString("abc")),
+        )
       }
       test("accumulates violations from multiple invalid elements") {
-        for result <- NonEmptySet("abc", "def").validateAs[NonEmptySet[Int]].flip
-        yield {
-          val violations = result.toList.map(_._2)
-          assertTrue(
-            violations.length == 2,
-            violations.contains(Violation.NonIntegerString("abc")),
-            violations.contains(Violation.NonIntegerString("def")),
-          )
-        }
+        val Left(result) = NonEmptySet("abc", "def").validateAs[NonEmptySet[Int]]: @unchecked
+        val violations   = result.toList.map(_._2)
+        assertTrue(
+          violations.length == 2,
+          violations.contains(Violation.NonIntegerString("abc")),
+          violations.contains(Violation.NonIntegerString("def")),
+        )
       }
     }
   }

--- a/zio-prelude/src/test/scala/yoshi/NonEmptySetSpec.scala
+++ b/zio-prelude/src/test/scala/yoshi/NonEmptySetSpec.scala
@@ -10,18 +10,18 @@ object NonEmptySetSpec extends ZIOSpecDefault {
   override def spec = suiteAll("NonEmptySet") {
     suiteAll("Set → NonEmptySet") {
       test("succeeds with non-empty set") {
-        assertTrue(Set(1, 2, 3).validateAs[NonEmptySet[Int]] == Right(NonEmptySet(1, 2, 3)))
+        assertTrue(Set(1, 2, 3).validateAs[NonEmptySet[Int]].is(_.right) == NonEmptySet(1, 2, 3))
       }
       test("fails with Violation.Required on empty set") {
-        assertTrue(Set.empty[Int].validateAs[NonEmptySet[Int]] == Left(Violations.of(Violation.Required)))
+        assertTrue(Set.empty[Int].validateAs[NonEmptySet[Int]].is(_.left) == Violations.of(Violation.Required))
       }
       test("succeeds with single element") {
-        assertTrue(Set(42).validateAs[NonEmptySet[Int]] == Right(NonEmptySet(42)))
+        assertTrue(Set(42).validateAs[NonEmptySet[Int]].is(_.right) == NonEmptySet(42))
       }
     }
     suiteAll("Set → NonEmptySet (element transform)") {
       test("transforms all elements") {
-        assertTrue(Set("1", "2", "3").validateAs[NonEmptySet[Int]] == Right(NonEmptySet(1, 2, 3)))
+        assertTrue(Set("1", "2", "3").validateAs[NonEmptySet[Int]].is(_.right) == NonEmptySet(1, 2, 3))
       }
       test("fails only for invalid elements in a mixed set") {
         val Left(result) = Set("abc", "2").validateAs[NonEmptySet[Int]]: @unchecked
@@ -34,7 +34,7 @@ object NonEmptySetSpec extends ZIOSpecDefault {
     }
     suiteAll("NonEmptySet element transform") {
       test("transforms all elements") {
-        assertTrue(NonEmptySet("1", "2", "3").validateAs[NonEmptySet[Int]] == Right(NonEmptySet(1, 2, 3)))
+        assertTrue(NonEmptySet("1", "2", "3").validateAs[NonEmptySet[Int]].is(_.right) == NonEmptySet(1, 2, 3))
       }
       test("fails when element transformation fails") {
         val Left(result) = NonEmptySet("abc").validateAs[NonEmptySet[Int]]: @unchecked


### PR DESCRIPTION
Removes the ZIO dependency from the core module by replacing all ZIO effect types with `Either`, making the library usable without a ZIO runtime and simplifying the API surface.