### PR TITLE
docs: add CI and Maven Central badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # yoshi
 
+[![CI](https://img.shields.io/github/actions/workflow/status/hshn/yoshi/ci.yml?branch=master&label=CI)](https://github.com/hshn/yoshi/actions/workflows/ci.yml)
+[![Maven Central](https://img.shields.io/maven-central/v/dev.hshn/yoshi_3?label=Maven%20Central)](https://central.sonatype.com/artifact/dev.hshn/yoshi_3)
+
 A validation library for Scala 3 that transforms untyped input into domain types — not just checking values, but parsing them into a stronger representation.
 
 ```scala


### PR DESCRIPTION
Add CI status and Maven Central version badges to the README for quick visibility into build health and the latest published version.