### PR TITLE
ci: migrate Renovate to config:recommended preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
## Summary

`config:base` is deprecated and renamed to `config:recommended`. Adopt the current preset name so the config keeps tracking Renovate's recommended defaults.

## Changes

- Switch the `extends` preset from `config:base` to `config:recommended`