### PR TITLE
fix: deny core-js build script to unblock pnpm v11 install

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -19,11 +19,6 @@
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.10.1"
   },
-  "pnpm": {
-    "overrides": {
-      "webpackbar": "^7.0.0"
-    }
-  },
   "browserslist": {
     "production": [">0.5%", "not dead", "not op_mini all"],
     "development": ["last 3 chrome version", "last 3 firefox version", "last 5 safari version"]

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  core-js: false


### PR DESCRIPTION
After pnpm v11, the Docs build fails at `pnpm install` because pnpm now refuses to silently skip dependency build scripts (`ERR_PNPM_IGNORED_BUILDS` for `core-js`) and no longer reads the `pnpm` field in `package.json`. The build-script decision is recorded explicitly instead: `core-js`'s install script (a funding notice, not needed to build the site) is denied.