### PR TITLE
fix: use yoshi-docs project id so docs build runs on sbt 2

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
             ~/.sbt
           key: sbt-docs-${{ hashFiles('build.sbt', 'project/**') }}
       - run: devbox run -- pnpm install --frozen-lockfile --dir website
-      - run: devbox run -- sbt docs/mdoc
+      - run: devbox run -- sbt yoshi-docs/mdoc
       - run: devbox run -- pnpm run --dir website build
       - uses: actions/upload-pages-artifact@v5
         with:


### PR DESCRIPTION
After the upgrade to sbt 2, the Docs build fails at `sbt docs/mdoc` because sbt 2 only resolves a project by its actual id, and the docs project's id is `yoshi-docs` (set via `.withId`, matching the `yoshi-*` convention of the other projects). sbt 1 also accepted the `lazy val` name `docs`; sbt 2 does not.
