### PR TITLE
fix(docs): show latest stable release version instead of snapshot

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - uses: jetify-com/devbox-install-action@v0.15.0
         with:
           enable-cache: true

--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,7 @@ lazy val docs = (project in file("docs")).withId("yoshi-docs")
     moduleName := "yoshi-docs",
     mdocIn := baseDirectory.value / "mdoc",
     mdocOut := (ThisBuild / baseDirectory).value / "website" / "docs",
-    mdocVariables := Map("VERSION" -> version.value),
+    mdocVariables := Map("VERSION" -> previousStableVersion.value.getOrElse(version.value)),
     scalacOptions -= "-Werror",
     publish / skip := true,
   )


### PR DESCRIPTION
The deployed docs advertised a broken snapshot coordinate (`0.0.0+1-e1706483-SNAPSHOT`) in the install snippet. The Docs workflow checked out the repo shallowly so sbt-dynver could not see any tag and fell back to a SNAPSHOT, which mdoc then embedded.